### PR TITLE
Rethrow the exception when failed to logging in

### DIFF
--- a/app/direct4b.hs
+++ b/app/direct4b.hs
@@ -105,20 +105,17 @@ login = do
     putStrLn $ "Parsed URL:" ++ show url
 
     let config = D.defaultConfig { D.directEndpointUrl = url }
-    eclient <- D.login config (directEmailAddress e) (directPassword e)
-    case eclient of
-        Left  _      -> putStrLn "Logged failed,"
-        Right client -> do
-            putStrLn "Successfully logged in."
+    client <- either E.throwIO return =<< D.login config (directEmailAddress e) (directPassword e)
+    putStrLn "Successfully logged in."
 
-            B.writeFile jsonFileName
-                $ D.serializePersistedInfo
-                $ D.clientPersistedInfo client
-            cd <- Dir.getCurrentDirectory
-            putStrLn
-                $  "Saved access token at '"
-                ++ (cd </> jsonFileName)
-                ++ "'."
+    B.writeFile jsonFileName
+        $ D.serializePersistedInfo
+        $ D.clientPersistedInfo client
+    cd <- Dir.getCurrentDirectory
+    putStrLn
+        $  "Saved access token at '"
+        ++ (cd </> jsonFileName)
+        ++ "'."
 
 sendText :: D.TalkId -> IO ()
 sendText tid = do


### PR DESCRIPTION
The exception can tell the email address and password are invalid.
Without this change, users would be confused.