### PR TITLE
Improve exception-handling

### DIFF
--- a/direct-hs.cabal
+++ b/direct-hs.cabal
@@ -18,6 +18,7 @@ library
   ghc-options:     -Wall
   exposed-modules: Web.Direct
   other-modules:   Web.Direct.Api
+                   Web.Direct.Exception
                    Web.Direct.Client
                    Web.Direct.Map
                    Web.Direct.Message

--- a/src/Web/Direct.hs
+++ b/src/Web/Direct.hs
@@ -63,6 +63,7 @@ module Web.Direct
 
 import           Web.Direct.Api
 import           Web.Direct.Client
+import           Web.Direct.Exception
 import           Web.Direct.Message
 import           Web.Direct.PersistedInfo
 import           Web.Direct.Types

--- a/src/Web/Direct/Client.hs
+++ b/src/Web/Direct/Client.hs
@@ -36,6 +36,7 @@ import qualified Data.IORef                               as I
 import qualified Data.MessagePack                         as M
 import qualified Network.MessagePack.RPC.Client.WebSocket as RPC
 
+import           Web.Direct.Exception
 import           Web.Direct.Message
 import           Web.Direct.PersistedInfo
 import           Web.Direct.Types
@@ -165,16 +166,18 @@ wait chan = C.takeMVar (fromWorker chan)
 
 ----------------------------------------------------------------
 
-sendMessage :: Client -> Message -> Aux -> IO MessageId
+sendMessage :: Client -> Message -> Aux -> IO (Either Exception MessageId)
 sendMessage client req aux = do
-    let obj = encodeMessage req aux
-    ersp <- RPC.call (clientRpcClient client) "create_message" obj
+    let obj        = encodeMessage req aux
+        methodName = "create_message"
+    ersp <- RPC.call (clientRpcClient client) methodName obj
     case ersp of
-        Right (M.ObjectMap rsp) ->
-            case lookup (M.ObjectStr "message_id") rsp of
-                Just (M.ObjectWord x) -> return x
-                _                     -> error "sendMessage" -- fixme
-        _ -> error "sendMessage" -- fixme
+        Right rsp@(M.ObjectMap rspMap) ->
+            case lookup (M.ObjectStr "message_id") rspMap of
+                Just (M.ObjectWord x) -> return $ Right x
+                _ -> return $ Left $ UnexpectedReponse methodName rsp
+        Right other -> return $ Left $ UnexpectedReponse methodName other
+        Left  other -> return $ Left $ UnexpectedReponse methodName other
 
 ----------------------------------------------------------------
 
@@ -196,7 +199,7 @@ recv chan = do
             void $ sendMessage (channelClient chan) announce (channelAux chan)
             E.throwIO E.ThreadKilled
 
-send :: Channel -> Message -> IO MessageId
+send :: Channel -> Message -> IO (Either Exception MessageId)
 send chan msg = sendMessage (channelClient chan) msg (channelAux chan)
 
 shutdown :: Client -> Message -> IO ()

--- a/src/Web/Direct/Client.hs
+++ b/src/Web/Direct/Client.hs
@@ -170,14 +170,16 @@ sendMessage :: Client -> Message -> Aux -> IO (Either Exception MessageId)
 sendMessage client req aux = do
     let obj        = encodeMessage req aux
         methodName = "create_message"
-    ersp <- RPC.call (clientRpcClient client) methodName obj
+    ersp <-
+        resultToObjectOrException methodName
+            <$> RPC.call (clientRpcClient client) methodName obj
     case ersp of
         Right rsp@(M.ObjectMap rspMap) ->
             case lookup (M.ObjectStr "message_id") rspMap of
                 Just (M.ObjectWord x) -> return $ Right x
                 _ -> return $ Left $ UnexpectedReponse methodName rsp
         Right other -> return $ Left $ UnexpectedReponse methodName other
-        Left  other -> return $ Left $ UnexpectedReponse methodName other
+        Left  other -> return $ Left other
 
 ----------------------------------------------------------------
 

--- a/src/Web/Direct/Exception.hs
+++ b/src/Web/Direct/Exception.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Web.Direct.Exception
+    ( Exception(..)
+    , callRpcThrow
+    , resultToObjectOrException
+    ) where
+
+
+import           Control.Error                            (fmapL)
+import qualified Control.Exception                        as E
+import qualified Data.MessagePack                         as M
+import qualified Data.MessagePack.RPC                     as RPC
+import           Data.Typeable                            (Typeable)
+import qualified Network.MessagePack.RPC.Client.WebSocket as RPC
+
+
+data Exception =
+      InvalidEmailOrPassword
+    | InvalidTalkId
+    | InvalidWsUrl !String
+    | UnexpectedReponse !RPC.MethodName !M.Object
+  deriving (Eq, Show, Typeable)
+
+instance E.Exception Exception
+
+
+resultToObjectOrException
+    :: RPC.MethodName -> RPC.Result -> Either Exception M.Object
+resultToObjectOrException methodName = fmapL $ \case
+    err@(M.ObjectMap errorMap) ->
+        case lookup (M.ObjectStr "message") errorMap of
+            Just (M.ObjectStr "invalid email or password") ->
+                InvalidEmailOrPassword
+            Just (M.ObjectStr "invalid talk_id") -> InvalidTalkId
+            _ -> UnexpectedReponse methodName err
+    other -> UnexpectedReponse methodName other
+
+
+callRpcThrow :: RPC.Client -> RPC.MethodName -> [M.Object] -> IO M.Object
+callRpcThrow rpcClient methodName args =
+    either E.throwIO return
+        =<< resultToObjectOrException methodName
+        <$> RPC.call rpcClient methodName args

--- a/src/Web/Direct/Types.hs
+++ b/src/Web/Direct/Types.hs
@@ -1,10 +1,7 @@
 module Web.Direct.Types where
 
-import qualified Control.Exception as E
-import qualified Data.MessagePack  as M
-import qualified Data.Text         as T
-import           Data.Typeable     (Typeable)
-import           Data.Word         (Word64)
+import qualified Data.Text as T
+import           Data.Word (Word64)
 
 ----------------------------------------------------------------
 
@@ -35,12 +32,3 @@ data TalkRoom = TalkRoom {
   , talkType  :: !TalkType
   , talkUsers :: [UserId]
   }
-----------------------------------------------------------------
-
-data Exception =
-      InvalidEmailOrPassword
-    | InvalidWsUrl !String
-    | UnexpectedReponse !M.Object
-  deriving (Eq, Show, Typeable)
-
-instance E.Exception Exception


### PR DESCRIPTION
1. Make a policy for exception-handling:
    - Public APIs return explicitly `IO (Either Exception a)`.
      To make them handlable by users and alert users by their documents.
    - Internal, and automatically called APIs `throwIO`-s.
      Because they are a bit hard to handle,
      and they should usually be successful without exceptions.
2. Add `methodName` field to `UnexpectedReponse` data constructor
    - To clarify which RPC calling throws an exception.
    - Would help detecting the cause without stack traces.
3. Refacor the verbose `void $ rethrowingException`-s with
   the new `callRpcThrow` function.
4. Avoid incomplete pattern-matches to throw the errors as
   `Web.Direct.Exception.Exception` as much as possible.