### PR TITLE
shutdown

### DIFF
--- a/direct-hs-examples/direct-hs-examples.cabal
+++ b/direct-hs-examples/direct-hs-examples.cabal
@@ -45,6 +45,7 @@ executable nippo
       base >=4.7 && <5
     , bytestring
     , direct-hs
+    , signal
     , text
   default-language: Haskell2010
   other-modules: Common

--- a/direct-hs-examples/src/nippo.hs
+++ b/direct-hs-examples/src/nippo.hs
@@ -6,6 +6,7 @@ import           Control.Monad          (forever, void)
 import qualified Data.ByteString.Lazy   as B
 import           Data.List              (find)
 import qualified Data.Text              as T
+import qualified System.Signal          as S
 import qualified Web.Direct             as D
 
 import           Common
@@ -18,7 +19,11 @@ main = do
                         , D.directCreateMessageHandler = handleCreateMessage
                         }
         pInfo
-        (\_ -> return ())
+        body
+  where
+    body client = do
+        S.installHandler S.sigTERM $ \_ ->
+          D.shutdown client $ D.Txt "BOTが終了します。\nこの作業は後からやり直してください。"
 
 handleCreateMessage :: D.Client -> D.Message -> D.Aux -> IO ()
 handleCreateMessage client (D.Txt txt) aux

--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -228,3 +228,4 @@ shutdown client msg = do
     chans <- allChannels client
     mapM_ (\chan -> control chan (Die msg)) chans
     wait client
+    RPC.shutdown $ clientRpcClient client

--- a/network-messagepack-rpc-websocket/src/Network/MessagePack/RPC/Client/WebSocket.hs
+++ b/network-messagepack-rpc-websocket/src/Network/MessagePack/RPC/Client/WebSocket.hs
@@ -15,6 +15,7 @@ module Network.MessagePack.RPC.Client.WebSocket (
   , URL
   , Client
   , withClient
+  , shutdown
     -- * Call and reply
   , Result
   , call

--- a/network-messagepack-rpc/src/Network/MessagePack/RPC/Client.hs
+++ b/network-messagepack-rpc/src/Network/MessagePack/RPC/Client.hs
@@ -15,13 +15,14 @@ module Network.MessagePack.RPC.Client
     -- * Client
   , Client
   , withClient
+  , shutdown
     -- * Call and reply
   , Result
   , call
   , reply
   ) where
 
-import           Control.Concurrent      (forkIO, forkFinally, killThread)
+import           Control.Concurrent      (forkIO, forkFinally, killThread, ThreadId)
 import           Control.Concurrent.MVar (MVar)
 import qualified Control.Concurrent.MVar as MVar
 import qualified Control.Exception.Safe  as E
@@ -44,6 +45,7 @@ data Client = Client {
   , clientBackend      :: !Backend
   , clientLog          :: Logger
   , clientFormat       :: Formatter
+  , clientHandlerTid   :: IORef (Maybe ThreadId)
   }
 
 data SessionState = SessionState {
@@ -177,8 +179,10 @@ withClient :: Config -> Backend -> (Client -> IO a) -> IO a
 withClient config backend action = do
     ss <- initSessionState
     wait <- MVar.newEmptyMVar
-    let client = Client ss backend (logger config) (formatter config)
+    tidref <- IORef.newIORef Nothing
+    let client = Client ss backend (logger config) (formatter config) tidref
     tid <- forkFinally (receiverThread client config) $ \_ -> MVar.putMVar wait ()
+    IORef.writeIORef tidref $ Just tid
     takeAction client wait `E.finally` killThread tid
   where
     takeAction client wait = do
@@ -186,3 +190,10 @@ withClient config backend action = do
         when (waitRequestHandler config) $ MVar.takeMVar wait
         backendClose backend
         return returned
+
+shutdown :: Client -> IO ()
+shutdown client = do
+    mtid <- IORef.readIORef $ clientHandlerTid client
+    case mtid of
+      Nothing  -> return ()
+      Just tid -> killThread tid


### PR DESCRIPTION
This patch enables graceful shutdown for `nippo` BOT:

```
% kill -TERM <PID>
```

To break the infinite loop of the handler, we need to kill the thread.