### PR TITLE
Upload file onto direct4b

### DIFF
--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -62,9 +62,29 @@ main = join $ Opt.execParser optionsInfo
                    "upload"
                    (Opt.info
                        (   uploadFile
-                       <$> optional (Opt.strOption (Opt.short 't' <> Opt.metavar "[MESSAGE_TEXT]"))
-                       <*> optional (Opt.strOption (Opt.short 'm' <> Opt.metavar "[MIME_TYPE]" <> Opt.help "Default \"application/octet-stream\"" ))
-                       <*> optional (Opt.option Opt.auto (Opt.short 'd' <> Opt.metavar "[DOMAIN_ID]" <> Opt.help "Default: the first domain you belong to." ))
+                       <$> optional
+                               (Opt.strOption
+                                   (  Opt.short 't'
+                                   <> Opt.metavar "[MESSAGE_TEXT]"
+                                   )
+                               )
+                       <*> optional
+                               (Opt.strOption
+                                   (  Opt.short 'm'
+                                   <> Opt.metavar "[MIME_TYPE]"
+                                   <> Opt.help
+                                          "Default \"application/octet-stream\""
+                                   )
+                               )
+                       <*> optional
+                               (Opt.option
+                                   Opt.auto
+                                   (  Opt.short 'd'
+                                   <> Opt.metavar "[DOMAIN_ID]"
+                                   <> Opt.help
+                                          "Default: the first domain you belong to."
+                                   )
+                               )
                        <*> Opt.argument Opt.auto (Opt.metavar "TALK_ID")
                        <*> Opt.strArgument (Opt.metavar "FILE_PATH")
                        )
@@ -196,19 +216,19 @@ uploadFile mtxt mmime mdid tid path = do
     let config = D.defaultConfig { D.directEndpointUrl = url }
     D.withClient config pInfo $ \client -> do
         did <- (`fromMaybe` mdid) . D.domainId . head <$> D.getDomains client
-        upf <- D.readToUpload mtxt (fromMaybe (judgeMimeFromName path) mmime) path
+        upf <- D.readToUpload mtxt
+                              (fromMaybe (judgeMimeFromName path) mmime)
+                              path
         void (either E.throwIO return =<< D.uploadFile client upf did tid)
-
   where
-    judgeMimeFromName p =
-        case takeExtension p of
-            ".txt"  -> "text/plain"
-            ".htm"  -> "text/html"
-            ".html" -> "text/html"
-            ".xml"  -> "text/xml"
-            ".gif"  -> "image/gif"
-            ".jpg"  -> "image/jpeg"
-            ".jpeg" -> "image/jpeg"
-            ".png"  -> "image/png"
-            ".pdf"  -> "application/pdf"
-            _       -> "application/octet-stream"
+    judgeMimeFromName p = case takeExtension p of
+        ".txt"  -> "text/plain"
+        ".htm"  -> "text/html"
+        ".html" -> "text/html"
+        ".xml"  -> "text/xml"
+        ".gif"  -> "image/gif"
+        ".jpg"  -> "image/jpeg"
+        ".jpeg" -> "image/jpeg"
+        ".png"  -> "image/png"
+        ".pdf"  -> "application/pdf"
+        _       -> "application/octet-stream"

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -79,8 +79,7 @@ main = join $ Opt.execParser optionsInfo
                        <*> optional
                                (Opt.option
                                    Opt.auto
-                                   (  Opt.short 'd'
-                                   <> Opt.metavar "[DOMAIN_ID]"
+                                   (Opt.short 'd' <> Opt.metavar "[DOMAIN_ID]"
                                    )
                                )
                        <*> Opt.argument Opt.auto (Opt.metavar "TALK_ID")

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -81,8 +81,6 @@ main = join $ Opt.execParser optionsInfo
                                    Opt.auto
                                    (  Opt.short 'd'
                                    <> Opt.metavar "[DOMAIN_ID]"
-                                   <> Opt.help
-                                          "Default: the first domain you belong to."
                                    )
                                )
                        <*> Opt.argument Opt.auto (Opt.metavar "TALK_ID")
@@ -205,7 +203,7 @@ showMsg (Msg.NotificationMessage method objs) =
 
 uploadFile
     :: Maybe T.Text     -- ^ Text message sent with the file.
-    -> Maybe T.Text     -- ^ MIME type of the file. Default: "application/octet-stream".
+    -> Maybe T.Text     -- ^ MIME type of the file.
     -> Maybe D.DomainId -- ^ The ID of domain onto which the file is uploaded. Default: the first domain obtained by `get_domains` RPC.
     -> D.TalkId         -- ^ The ID of talk room onto which the file is uploaded.
     -> FilePath         -- ^ The path to file.

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -215,7 +215,8 @@ uploadFile mtxt mmime mdid tid path = do
     let config = D.defaultConfig { D.directEndpointUrl = url }
     D.withClient config pInfo $ \client -> do
         did <- (`fromMaybe` mdid) . D.domainId . head <$> D.getDomains client
-        upf <- D.readToUpload mtxt
-                              (fromMaybe (TE.decodeUtf8 $ defaultMimeLookup $ T.pack path) mmime)
-                              path
+        upf <- D.readToUpload
+            mtxt
+            (fromMaybe (TE.decodeUtf8 $ defaultMimeLookup $ T.pack path) mmime)
+            path
         void (either E.throwIO return =<< D.uploadFile client upf did tid)

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -193,12 +193,11 @@ uploadFile
 uploadFile mtxt mmime mdid tid path = do
     pInfo <- dieWhenLeft . D.deserializeLoginInfo =<< B.readFile jsonFileName
     (EndpointUrl url) <- dieWhenLeft =<< decodeEnv
-    let aux    = D.defaultAux { D.auxTalkId = tid }
-        config = D.defaultConfig { D.directEndpointUrl = url }
+    let config = D.defaultConfig { D.directEndpointUrl = url }
     D.withClient config pInfo $ \client -> do
-        dom <- (`fromMaybe` mdid) . D.domainId . head <$> D.getDomains client
-        upf <- D.readToUpload dom mtxt (fromMaybe (judgeMimeFromName path) mmime) path
-        void (either E.throwIO return =<< D.uploadFile client upf aux)
+        did <- (`fromMaybe` mdid) . D.domainId . head <$> D.getDomains client
+        upf <- D.readToUpload mtxt (fromMaybe (judgeMimeFromName path) mmime) path
+        void (either E.throwIO return =<< D.uploadFile client upf did tid)
 
   where
     judgeMimeFromName p =

--- a/direct-hs/direct-hs.cabal
+++ b/direct-hs/direct-hs.cabal
@@ -37,7 +37,9 @@ library
     , containers
     , data-msgpack
     , errors
+    , filepath
     , http-client
+    , http-client-tls
     , http-types
     , mtl
     , mwc-random

--- a/direct-hs/direct-hs.cabal
+++ b/direct-hs/direct-hs.cabal
@@ -66,6 +66,7 @@ executable direct4b
     , optparse-applicative
     , envy
     , text
+    , mime-types
     , network-messagepack-rpc
   default-language: Haskell2010
 

--- a/direct-hs/direct-hs.cabal
+++ b/direct-hs/direct-hs.cabal
@@ -28,6 +28,7 @@ library
                    Web.Direct.LoginInfo
                    Web.Direct.Message
                    Web.Direct.Types
+                   Web.Direct.Upload
                    Web.Direct.Utils
   build-depends:
       base >= 4.7 && < 5
@@ -36,9 +37,12 @@ library
     , containers
     , data-msgpack
     , errors
+    , http-client
+    , http-types
+    , mtl
+    , mwc-random
     , network-messagepack-rpc
     , network-messagepack-rpc-websocket
-    , mwc-random
     , stm
     , text
     , unordered-containers

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -46,6 +46,10 @@ module Web.Direct
     , Message(..)
   -- * Sending
     , sendMessage
+  -- ** File Upload
+    , UploadFile(..)
+    , readToUpload
+    , uploadFile
   -- * Channel
   -- ** Channel type
     , ChannelType
@@ -68,12 +72,12 @@ where
 
 import           Web.Direct.Api
 import           Web.Direct.Client
+import           Web.Direct.DirectRPC hiding (getDomains)
 import           Web.Direct.Exception
 import           Web.Direct.LoginInfo
 import           Web.Direct.Message
 import           Web.Direct.Types
-
-import           Web.Direct.DirectRPC hiding (getDomains)
+import           Web.Direct.Upload
 
 createPair :: Client -> User -> IO TalkRoom
 createPair client = createPairTalk (clientRpcClient client)

--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -122,7 +122,12 @@ sendMessage client req tid = createMessage (clientRpcClient client) req tid
 
 ----------------------------------------------------------------
 
-uploadFile :: Client -> UploadFile -> DomainId -> TalkId -> IO (Either Exception MessageId)
+uploadFile
+    :: Client
+    -> UploadFile
+    -> DomainId
+    -> TalkId
+    -> IO (Either Exception MessageId)
 uploadFile client upf@UploadFile {..} did tid = runExceptT $ do
     ua@UploadAuth {..} <- ExceptT $ createUploadAuth
         (clientRpcClient client)

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -115,3 +115,21 @@ createPairTalk rpcclient peer = do
         dat        = [M.ObjectWord did, M.ObjectWord uid]
     rsp <- callRpcThrow rpcclient methodName dat
     convertOrThrow methodName (decodeTalkRoom [peer]) rsp -- fixme: users
+
+createUploadAuth :: RPC.Client -> Text -> Text -> FileSize -> DomainId -> IO (Either Exception UploadAuth)
+createUploadAuth rpcclient fn mimeType fileSize did = do
+    let methodName = "create_upload_auth"
+        obj =
+            [ M.ObjectStr fn
+            , M.ObjectStr mimeType
+            , M.ObjectWord fileSize
+            , M.ObjectWord did
+            ]
+    eres <- callRpc rpcclient methodName obj
+    case eres of
+        Right rsp@(M.ObjectMap rspMap) ->
+            case decodeUploadAuth rspMap of
+                Just ua -> return $ Right ua
+                _       -> return $ Left $ UnexpectedReponse methodName rsp
+        Right other -> return $ Left $ UnexpectedReponse methodName other
+        Left e -> return $ Left e

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -116,7 +116,13 @@ createPairTalk rpcclient peer = do
     rsp <- callRpcThrow rpcclient methodName dat
     convertOrThrow methodName (decodeTalkRoom [peer]) rsp -- fixme: users
 
-createUploadAuth :: RPC.Client -> Text -> Text -> FileSize -> DomainId -> IO (Either Exception UploadAuth)
+createUploadAuth
+    :: RPC.Client
+    -> Text
+    -> Text
+    -> FileSize
+    -> DomainId
+    -> IO (Either Exception UploadAuth)
 createUploadAuth rpcclient fn mimeType fileSize did = do
     let methodName = "create_upload_auth"
         obj =
@@ -127,9 +133,8 @@ createUploadAuth rpcclient fn mimeType fileSize did = do
             ]
     eres <- callRpc rpcclient methodName obj
     case eres of
-        Right rsp@(M.ObjectMap rspMap) ->
-            case decodeUploadAuth rspMap of
-                Just ua -> return $ Right ua
-                _       -> return $ Left $ UnexpectedReponse methodName rsp
+        Right rsp@(M.ObjectMap rspMap) -> case decodeUploadAuth rspMap of
+            Just ua -> return $ Right ua
+            _       -> return $ Left $ UnexpectedReponse methodName rsp
         Right other -> return $ Left $ UnexpectedReponse methodName other
-        Left e -> return $ Left e
+        Left  e     -> return $ Left e

--- a/direct-hs/src/Web/Direct/DirectRPC/Map.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC/Map.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module Web.Direct.DirectRPC.Map where
 
@@ -71,3 +72,16 @@ decodeTalkRoom (me : others) (M.ObjectMap m) = do
     extract _                  = Nothing
 decodeTalkRoom _ _ = Nothing
 
+decodeUploadAuth
+    :: [(M.Object, M.Object)]
+    -> Maybe UploadAuth
+decodeUploadAuth rspMap = do
+    M.ObjectStr uploadAuthGetUrl <- lookup (M.ObjectStr "get_url") rspMap
+    M.ObjectStr uploadAuthPutUrl <- lookup (M.ObjectStr "put_url") rspMap
+    M.ObjectWord uploadAuthFileId <- lookup (M.ObjectStr "file_id") rspMap
+
+    M.ObjectMap formObj <- lookup (M.ObjectStr "post_form") rspMap
+    M.ObjectStr uploadAuthContentDisposition <- lookup
+        (M.ObjectStr "Content-Disposition")
+        formObj
+    return UploadAuth {..}

--- a/direct-hs/src/Web/Direct/DirectRPC/Map.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC/Map.hs
@@ -72,9 +72,7 @@ decodeTalkRoom (me : others) (M.ObjectMap m) = do
     extract _                  = Nothing
 decodeTalkRoom _ _ = Nothing
 
-decodeUploadAuth
-    :: [(M.Object, M.Object)]
-    -> Maybe UploadAuth
+decodeUploadAuth :: [(M.Object, M.Object)] -> Maybe UploadAuth
 decodeUploadAuth rspMap = do
     M.ObjectStr uploadAuthGetUrl <- lookup (M.ObjectStr "get_url") rspMap
     M.ObjectStr uploadAuthPutUrl <- lookup (M.ObjectStr "put_url") rspMap

--- a/direct-hs/src/Web/Direct/Exception.hs
+++ b/direct-hs/src/Web/Direct/Exception.hs
@@ -15,6 +15,7 @@ import qualified Control.Exception                        as E
 import qualified Data.MessagePack                         as M
 import qualified Data.MessagePack.RPC                     as RPC
 import           Data.Typeable                            (Typeable)
+import           Network.HTTP.Types.Status                (Status)
 import qualified Network.MessagePack.RPC.Client.WebSocket as RPC
 
 
@@ -22,6 +23,7 @@ data Exception =
       InvalidEmailOrPassword
     | InvalidTalkId
     | InvalidWsUrl !String
+    | UnexpectedReponseWhenUpload Status
     | UnexpectedReponse !RPC.MethodName !M.Object
   deriving (Eq, Show, Typeable)
 

--- a/direct-hs/src/Web/Direct/Message.hs
+++ b/direct-hs/src/Web/Direct/Message.hs
@@ -1,11 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module Web.Direct.Message where
 
-import           Data.List        (elemIndex)
-import qualified Data.MessagePack as M
-import qualified Data.Text        as T
-import           Data.Word        (Word64)
+import           Control.Applicative ((<|>))
+import           Control.Monad       (mapM)
+import           Data.List           (elemIndex)
+import           Data.Maybe          (maybeToList)
+import qualified Data.MessagePack    as M
+import qualified Data.Text           as T
+import           Data.Word           (Word64)
 
 import           Web.Direct.Types
 import           Web.Direct.Utils
@@ -23,8 +27,17 @@ data Message =
   | SelectA   !T.Text ![T.Text] T.Text
   | TaskQ     !T.Text Bool -- False: anyone, True: everyone
   | TaskA     !T.Text Bool Bool -- done
+  | Files     ![File] !(Maybe T.Text)
   | Other     !T.Text
   deriving (Eq, Show)
+
+data File = File
+    { fileUrl         :: !T.Text
+    , fileContentType :: !T.Text
+    , fileContentSize :: !Word64
+    , fileName        :: !T.Text
+    , fileId          :: !FileId
+    } deriving (Eq, Show)
 
 ----------------------------------------------------------------
 
@@ -52,6 +65,19 @@ encodeMessage (Stamp set idx (Just txt)) tid =
         , (M.ObjectStr "stamp_index", M.ObjectWord idx)
         , (M.ObjectStr "text"       , M.ObjectStr txt)
         ]
+    ]
+encodeMessage (Files [file] Nothing)  (Aux tid _ _) =
+    [ M.ObjectWord tid
+    , M.ObjectWord 4
+    , encodeFile file
+    ]
+encodeMessage (Files files mtext) (Aux tid _ _) =
+    [ M.ObjectWord tid
+    , M.ObjectWord 5
+    , M.ObjectMap
+        $ (M.ObjectStr "files", M.ObjectArray $ map encodeFile files)
+        : maybeToList (fmap (\text -> (M.ObjectStr "text" , M.ObjectStr text)) mtext)
+        -- TODO: Try <$> [multiple files, single file] <*> [has text, no text]
     ]
 encodeMessage (YesNoQ qst) tid =
     [ M.ObjectWord tid
@@ -111,6 +137,16 @@ encodeMessage (TaskA ttl cls don) tid =
 encodeMessage (Other text) tid =
     [M.ObjectWord tid, M.ObjectWord 1, M.ObjectStr text]
 
+encodeFile :: File -> M.Object
+encodeFile File {..} =
+    M.ObjectMap
+        [ (M.ObjectStr "url", M.ObjectStr fileUrl)
+        , (M.ObjectStr "file_id", M.ObjectWord fileId)
+        , (M.ObjectStr "name", M.ObjectStr fileName)
+        , (M.ObjectStr "content_type", M.ObjectStr fileContentType)
+        , (M.ObjectStr "content_size", M.ObjectWord fileContentSize)
+        ]
+
 ----------------------------------------------------------------
 
 decodeMessage
@@ -140,6 +176,24 @@ decodeMessage rspinfo = do
                 idx           <- look "stamp_index" m >>= M.fromObject
                 let txt = look "text" m >>= M.fromObject
                 return (Stamp set idx txt)
+            M.ObjectWord 4 -> do -- TODO: refactor with the case of (M.ObjectWord 5)
+                obj@(M.ObjectMap m) <- look "content" rspinfo
+                fs <- ((: []) <$> decodeFile obj) <|> decodeFiles m
+                let text =
+                        case look "text" m of
+                            Just (M.ObjectStr t) -> Just t
+                            Just _other          -> Nothing
+                            Nothing              -> Nothing
+                Just (Files fs text, aux)
+            M.ObjectWord 5 -> do
+                obj@(M.ObjectMap m) <- look "content" rspinfo
+                fs <- ((: []) <$> decodeFile obj) <|> decodeFiles m
+                let text =
+                        case look "text" m of
+                            Just (M.ObjectStr t) -> Just t
+                            Just _other          -> Nothing
+                            Nothing              -> Nothing
+                Just (Files fs text, aux)
             M.ObjectWord 500 -> do
                 M.ObjectMap m <- look "content" rspinfo
                 qst           <- look "question" m >>= M.fromObject
@@ -175,3 +229,16 @@ decodeMessage rspinfo = do
                 let cls = cls' == (1 :: Word64)
                 return (TaskA ttl cls don)
             _ -> return (Other $ T.pack $ show rspinfo)
+
+    decodeFiles m = do
+        M.ObjectArray xs <- look "files" m
+        mapM decodeFile xs
+
+    decodeFile (M.ObjectMap f) = do
+        M.ObjectWord fileId <- look "file_id" f
+        M.ObjectStr fileName <- look "name" f
+        M.ObjectStr fileContentType <- look "content_type" f
+        M.ObjectWord fileContentSize <-  look "content_size" f
+        M.ObjectStr fileUrl <- look "url" f
+        Just File {..}
+    decodeFile _ = Nothing

--- a/direct-hs/src/Web/Direct/Types.hs
+++ b/direct-hs/src/Web/Direct/Types.hs
@@ -13,6 +13,8 @@ type TalkId    = Word64
 type UserId    = Word64
 -- | Mesage ID.
 type MessageId = Word64
+-- | (Uploaded) File ID.
+type FileId    = Word64
 
 ----------------------------------------------------------------
 

--- a/direct-hs/src/Web/Direct/Types.hs
+++ b/direct-hs/src/Web/Direct/Types.hs
@@ -15,6 +15,8 @@ type UserId    = Word64
 type MessageId = Word64
 -- | (Uploaded) File ID.
 type FileId    = Word64
+-- | (Uploaded) File size in bytes.
+type FileSize  = Word64
 
 ----------------------------------------------------------------
 
@@ -42,3 +44,12 @@ data TalkRoom = TalkRoom {
   , talkType  :: !TalkType
   , talkUsers :: [User] -- ^ The head of this list is myself.
   } deriving (Eq, Show)
+
+-- | Created from the response of direct's RPC function @create_upload_auth@.
+--   Contains information to upload/download a file to/from direct.
+data UploadAuth = UploadAuth
+    { uploadAuthGetUrl             :: !T.Text
+    , uploadAuthPutUrl             :: !T.Text
+    , uploadAuthFileId             :: !FileId
+    , uploadAuthContentDisposition :: !T.Text
+    }

--- a/direct-hs/src/Web/Direct/Upload.hs
+++ b/direct-hs/src/Web/Direct/Upload.hs
@@ -15,7 +15,7 @@ import qualified Data.Text.Encoding        as TE
 import           Data.Word                 (Word64)
 import qualified Network.HTTP.Client       as H
 import           Network.HTTP.Client.TLS   (tlsManagerSettings)
-import           Network.HTTP.Types.Status (Status (statusCode))
+import           Network.HTTP.Types.Status (statusIsSuccessful)
 import qualified System.FilePath           as FP
 
 import           Web.Direct.Exception
@@ -59,7 +59,6 @@ runUploadFile UploadFile {..} UploadAuth {..} = do
             }
     res <- H.httpNoBody req mgr
     let st = H.responseStatus res
-        sc = statusCode st
-    if 200 <= sc && sc < 300
+    if statusIsSuccessful st
         then return $ Right ()
         else return $ Left $ UnexpectedReponseWhenUpload st

--- a/direct-hs/src/Web/Direct/Upload.hs
+++ b/direct-hs/src/Web/Direct/Upload.hs
@@ -3,34 +3,40 @@
 
 module Web.Direct.Upload
     ( UploadFile(..)
+    , UploadAuth(..)
     , readToUpload
     , decodeUploadAuth
     , toCreateUploadAuth
     , runUploadFile
     ) where
 
-import           Control.Error        (note)
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.MessagePack     as M
-import           Data.MessagePack.RPC (MethodName)
-import qualified Data.Text            as T
-import           Data.Word            (Word64)
+import           Control.Error             (note)
+import qualified Data.ByteString.Lazy      as BL
+import qualified Data.MessagePack          as M
+import           Data.MessagePack.RPC      (MethodName)
+import qualified Data.Text                 as T
+import qualified Data.Text.Encoding        as TE
+import           Data.Word                 (Word64)
+import qualified Network.HTTP.Client       as H
+import           Network.HTTP.Client.TLS   (tlsManagerSettings)
+import           Network.HTTP.Types.Status (Status (statusCode))
+import qualified System.FilePath           as FP
 
 import           Web.Direct.Exception
 import           Web.Direct.Types
 
 
+-- | Currently, only one file can be uploaded per once.
 data UploadFile = UploadFile
-    { uploadFileContent  :: !BL.ByteString
-    , uploadFileName     :: !T.Text
-    , uploadFileMimeType :: !(Maybe T.Text)
-    , uploadFileSize     :: !Word64
+    { uploadFileDomainId     :: !DomainId
+    , uploadFileAttachedText :: !(Maybe T.Text)
+    , uploadFileMimeType     :: !T.Text
+    , uploadFileName         :: !T.Text
+    , uploadFileContent      :: !BL.ByteString
+    , uploadFileSize         :: !Word64
     }
 
 
--- TODO: Send with PUT.
--- TODO: As long as I remember,
--- all values in post_form of the response of create_upload_auth are appended as the query parameter
 data UploadAuth = UploadAuth
     { uploadAuthGetUrl             :: !T.Text
     , uploadAuthPutUrl             :: !T.Text
@@ -39,29 +45,61 @@ data UploadAuth = UploadAuth
     }
 
 
-readToUpload :: Maybe T.Text -> FilePath -> IO UploadFile
-readToUpload mimeType path =
-    error "TODO: readToUpload is not defined yet!"
+readToUpload :: DomainId -> Maybe T.Text -> T.Text -> FilePath -> IO UploadFile
+readToUpload uploadFileDomainId uploadFileAttachedText uploadFileMimeType path
+    = do
+        let uploadFileName = T.pack $ FP.takeFileName path
+        uploadFileContent <- BL.readFile path
+        let uploadFileSize = fromIntegral $ BL.length uploadFileContent
+        return UploadFile {..}
 
 
 toCreateUploadAuth :: UploadFile -> [M.Object]
-toCreateUploadAuth _ =
-    error "TODO: toCreateUploadAuth is not defined yet!"
+toCreateUploadAuth UploadFile {..} =
+    [ M.ObjectStr uploadFileName
+    , M.ObjectStr uploadFileMimeType
+    , M.ObjectWord uploadFileSize
+    , M.ObjectWord uploadFileDomainId
+    ]
 
 
-decodeUploadAuth :: MethodName -> M.Object -> [(M.Object, M.Object)] -> Either Exception UploadAuth
+decodeUploadAuth
+    :: MethodName
+    -> M.Object
+    -> [(M.Object, M.Object)]
+    -> Either Exception UploadAuth
 decodeUploadAuth methodName rsp rspMap =
     note (UnexpectedReponse methodName rsp) $ do
-        M.ObjectStr uploadAuthGetUrl             <- lookup (M.ObjectStr "get_url") rspMap
-        M.ObjectStr uploadAuthPutUrl             <- lookup (M.ObjectStr "put_url") rspMap
-        M.ObjectWord uploadAuthFileId            <- lookup (M.ObjectStr "file_id") rspMap
+        M.ObjectStr uploadAuthGetUrl <- lookup (M.ObjectStr "get_url") rspMap
+        M.ObjectStr uploadAuthPutUrl <- lookup (M.ObjectStr "put_url") rspMap
+        M.ObjectWord uploadAuthFileId <- lookup (M.ObjectStr "file_id") rspMap
 
-        M.ObjectMap formObj                      <- lookup (M.ObjectStr "post_form") rspMap
-        M.ObjectStr uploadAuthContentDisposition <- lookup (M.ObjectStr "Content-Disposition") formObj
+        M.ObjectMap formObj <- lookup (M.ObjectStr "post_form") rspMap
+        M.ObjectStr uploadAuthContentDisposition <- lookup
+            (M.ObjectStr "Content-Disposition")
+            formObj
         return UploadAuth {..}
 
 
 runUploadFile :: UploadFile -> UploadAuth -> IO (Either Exception ())
-runUploadFile UploadFile {..} UploadAuth {..} =
-    error "TODO: runUploadFile is not defined yet!"
-    -- TODO: run httpNoBody to put_url with PUT, add header Content-Type and Content-Disposition from post_form
+runUploadFile UploadFile {..} UploadAuth {..} = do
+    mgr <- H.newManager tlsManagerSettings
+    req0    <- H.parseRequest $ T.unpack uploadAuthPutUrl
+    let
+        req = req0
+            { H.method         = "PUT"
+            , H.requestHeaders = [ ( "Content-Disposition"
+                                   , TE.encodeUtf8 uploadAuthContentDisposition
+                                   )
+                                 , ( "Content-Type"
+                                   , TE.encodeUtf8 uploadFileMimeType
+                                   )
+                                 ]
+            , H.requestBody    = H.RequestBodyLBS uploadFileContent
+            }
+    res <- H.httpNoBody req mgr
+    let st = H.responseStatus res
+        sc = statusCode st
+    if 200 <= sc && sc < 300
+      then return $ Right ()
+      else return $ Left $ UnexpectedReponseWhenUpload st

--- a/direct-hs/src/Web/Direct/Upload.hs
+++ b/direct-hs/src/Web/Direct/Upload.hs
@@ -15,6 +15,8 @@ import qualified Data.Text.Encoding        as TE
 import           Data.Word                 (Word64)
 import qualified Network.HTTP.Client       as H
 import           Network.HTTP.Client.TLS   (tlsManagerSettings)
+import           Network.HTTP.Types.Header (hContentDisposition, hContentType)
+import           Network.HTTP.Types.Method (methodPut)
 import           Network.HTTP.Types.Status (statusIsSuccessful)
 import qualified System.FilePath           as FP
 
@@ -47,11 +49,11 @@ runUploadFile UploadFile {..} UploadAuth {..} = do
     req0 <- H.parseRequest $ T.unpack uploadAuthPutUrl
     let
         req = req0
-            { H.method         = "PUT"
-            , H.requestHeaders = [ ( "Content-Disposition"
+            { H.method         = methodPut
+            , H.requestHeaders = [ ( hContentDisposition
                                    , TE.encodeUtf8 uploadAuthContentDisposition
                                    )
-                                 , ( "Content-Type"
+                                 , ( hContentType
                                    , TE.encodeUtf8 uploadFileMimeType
                                    )
                                  ]

--- a/direct-hs/src/Web/Direct/Upload.hs
+++ b/direct-hs/src/Web/Direct/Upload.hs
@@ -6,7 +6,8 @@ module Web.Direct.Upload
     , UploadAuth(..)
     , readToUpload
     , runUploadFile
-    ) where
+    )
+where
 
 import qualified Data.ByteString.Lazy      as BL
 import qualified Data.Text                 as T
@@ -33,18 +34,17 @@ data UploadFile = UploadFile
 
 
 readToUpload :: Maybe T.Text -> T.Text -> FilePath -> IO UploadFile
-readToUpload uploadFileAttachedText uploadFileMimeType path
-    = do
-        let uploadFileName = T.pack $ FP.takeFileName path
-        uploadFileContent <- BL.readFile path
-        let uploadFileSize = fromIntegral $ BL.length uploadFileContent
-        return UploadFile {..}
+readToUpload uploadFileAttachedText uploadFileMimeType path = do
+    let uploadFileName = T.pack $ FP.takeFileName path
+    uploadFileContent <- BL.readFile path
+    let uploadFileSize = fromIntegral $ BL.length uploadFileContent
+    return UploadFile {..}
 
 
 runUploadFile :: UploadFile -> UploadAuth -> IO (Either Exception ())
 runUploadFile UploadFile {..} UploadAuth {..} = do
-    mgr <- H.newManager tlsManagerSettings
-    req0    <- H.parseRequest $ T.unpack uploadAuthPutUrl
+    mgr  <- H.newManager tlsManagerSettings
+    req0 <- H.parseRequest $ T.unpack uploadAuthPutUrl
     let
         req = req0
             { H.method         = "PUT"
@@ -61,5 +61,5 @@ runUploadFile UploadFile {..} UploadAuth {..} = do
     let st = H.responseStatus res
         sc = statusCode st
     if 200 <= sc && sc < 300
-      then return $ Right ()
-      else return $ Left $ UnexpectedReponseWhenUpload st
+        then return $ Right ()
+        else return $ Left $ UnexpectedReponseWhenUpload st

--- a/direct-hs/src/Web/Direct/Upload.hs
+++ b/direct-hs/src/Web/Direct/Upload.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+module Web.Direct.Upload
+    ( UploadFile(..)
+    , readToUpload
+    , decodeUploadAuth
+    , toCreateUploadAuth
+    , runUploadFile
+    ) where
+
+import           Control.Error        (note)
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.MessagePack     as M
+import           Data.MessagePack.RPC (MethodName)
+import qualified Data.Text            as T
+import           Data.Word            (Word64)
+
+import           Web.Direct.Exception
+import           Web.Direct.Types
+
+
+data UploadFile = UploadFile
+    { uploadFileContent  :: !BL.ByteString
+    , uploadFileName     :: !T.Text
+    , uploadFileMimeType :: !(Maybe T.Text)
+    , uploadFileSize     :: !Word64
+    }
+
+
+-- TODO: Send with PUT.
+-- TODO: As long as I remember,
+-- all values in post_form of the response of create_upload_auth are appended as the query parameter
+data UploadAuth = UploadAuth
+    { uploadAuthGetUrl             :: !T.Text
+    , uploadAuthPutUrl             :: !T.Text
+    , uploadAuthFileId             :: !FileId
+    , uploadAuthContentDisposition :: !T.Text
+    }
+
+
+readToUpload :: Maybe T.Text -> FilePath -> IO UploadFile
+readToUpload mimeType path =
+    error "TODO: readToUpload is not defined yet!"
+
+
+toCreateUploadAuth :: UploadFile -> [M.Object]
+toCreateUploadAuth _ =
+    error "TODO: toCreateUploadAuth is not defined yet!"
+
+
+decodeUploadAuth :: MethodName -> M.Object -> [(M.Object, M.Object)] -> Either Exception UploadAuth
+decodeUploadAuth methodName rsp rspMap =
+    note (UnexpectedReponse methodName rsp) $ do
+        M.ObjectStr uploadAuthGetUrl             <- lookup (M.ObjectStr "get_url") rspMap
+        M.ObjectStr uploadAuthPutUrl             <- lookup (M.ObjectStr "put_url") rspMap
+        M.ObjectWord uploadAuthFileId            <- lookup (M.ObjectStr "file_id") rspMap
+
+        M.ObjectMap formObj                      <- lookup (M.ObjectStr "post_form") rspMap
+        M.ObjectStr uploadAuthContentDisposition <- lookup (M.ObjectStr "Content-Disposition") formObj
+        return UploadAuth {..}
+
+
+runUploadFile :: UploadFile -> UploadAuth -> IO (Either Exception ())
+runUploadFile UploadFile {..} UploadAuth {..} =
+    error "TODO: runUploadFile is not defined yet!"
+    -- TODO: run httpNoBody to put_url with PUT, add header Content-Type and Content-Disposition from post_form


### PR DESCRIPTION
- :new: Add `uploadFile` function which uploads a file to direct4b.com.  
  To imitate the file upload feature of direct on a web browser, this function does:

    1. Calls `create_upload_auth` RPC function to get the URL to upload.
    1. Then uploads the file by sending a PUT request to the URL (`runUploadFile`).
    1. Calls `sendMessage` to notify the files is uploaded.
- :new: Add `Files` value constructor to type `Message`, representing a message with uploaded file(s) with its decoder and encoder.
- :new: Add `upload` subcommand to `direct4b`
    - Intended to use in a shell script which send a report with a file.
    - And of course useful for testing this feature!
    - The MIME type of the uploaded file is judged from the file name automatically or specified by the `-m` option, like daab's same feature.
