### PR TITLE
Fix `direct4b send` command doesn't stop + some docs

### DIFF
--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -214,7 +214,9 @@ uploadFile
 uploadFile mtxt mmime mdid tid path = do
     pInfo <- dieWhenLeft . D.deserializeLoginInfo =<< B.readFile jsonFileName
     (EndpointUrl url) <- dieWhenLeft =<< decodeEnv
-    let config = D.defaultConfig { D.directEndpointUrl = url }
+    let config = D.defaultConfig { D.directEndpointUrl              = url
+                                 , D.directWaitCreateMessageHandler = False
+                                 }
     D.withClient config pInfo $ \client -> do
         did <- (`fromMaybe` mdid) . D.domainId . head <$> D.getDomains client
         upf <- D.readToUpload

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -151,7 +151,7 @@ sendText tid = do
     txt <- TL.stripEnd <$> TL.getContents
     pInfo <- dieWhenLeft . D.deserializeLoginInfo =<< B.readFile jsonFileName
     (EndpointUrl url) <- dieWhenLeft =<< decodeEnv
-    let config = D.defaultConfig { D.directEndpointUrl = url }
+    let config = D.defaultConfig { D.directEndpointUrl = url, D.directWaitCreateMessageHandler = False }
     D.withClient config pInfo $ \client -> forM_ (TL.chunksOf 1024 txt)
         $ \chunk -> D.sendMessage client (D.Txt $ TL.toStrict chunk) tid
 

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -151,7 +151,9 @@ sendText tid = do
     txt <- TL.stripEnd <$> TL.getContents
     pInfo <- dieWhenLeft . D.deserializeLoginInfo =<< B.readFile jsonFileName
     (EndpointUrl url) <- dieWhenLeft =<< decodeEnv
-    let config = D.defaultConfig { D.directEndpointUrl = url, D.directWaitCreateMessageHandler = False }
+    let config = D.defaultConfig { D.directEndpointUrl              = url
+                                 , D.directWaitCreateMessageHandler = False
+                                 }
     D.withClient config pInfo $ \client -> forM_ (TL.chunksOf 1024 txt)
         $ \chunk -> D.sendMessage client (D.Txt $ TL.toStrict chunk) tid
 

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -54,7 +54,7 @@ defaultConfig = Config
     { directCreateMessageHandler     = \_ _ -> return ()
     , directLogger                   = \_ -> return ()
     , directFormatter                = show
-    , directEndpointUrl              = "wss://api.direct4b.com/albero-app-server/api"
+    , directEndpointUrl = "wss://api.direct4b.com/albero-app-server/api"
     , directWaitCreateMessageHandler = True
     }
 

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -30,10 +30,18 @@ import           Web.Direct.Types
 
 -- | Type for client configuration.
 data Config = Config {
-    directCreateMessageHandler :: Client -> (Message,MessageId,TalkRoom,User) -> IO ()
-  , directLogger               :: RPC.Logger
-  , directFormatter            :: RPC.Formatter
-  , directEndpointUrl          :: RPC.URL -- Endpoint URL for direct WebSocket API.
+    directCreateMessageHandler     :: Client -> (Message, MessageId, TalkRoom, User) -> IO ()
+    -- ^ Called every time receiving a new message from the server.
+  , directLogger                   :: RPC.Logger
+  , directFormatter                :: RPC.Formatter
+  , directEndpointUrl              :: RPC.URL
+    -- ^ Endpoint URL for direct WebSocket API.
+  , directWaitCreateMessageHandler :: Bool
+    -- ^ If @True@, 'withClient' function doesen't finish until the
+    --   'directCreateMessageHandler' thread finish.
+    --   Disable this to write a batch application, which just send a message
+    --   once or more, then finishes.
+    --   Default: @True@.
   }
 
 -- | The default configuration.
@@ -43,17 +51,18 @@ data Config = Config {
 --   * 'directEndpointUrl' is 'wss://api.direct4b.com/albero-app-server/api'
 defaultConfig :: Config
 defaultConfig = Config
-    { directCreateMessageHandler = \_ _ -> return ()
-    , directLogger               = \_ -> return ()
-    , directFormatter            = show
-    , directEndpointUrl = "wss://api.direct4b.com/albero-app-server/api"
+    { directCreateMessageHandler     = \_ _ -> return ()
+    , directLogger                   = \_ -> return ()
+    , directFormatter                = show
+    , directEndpointUrl              = "wss://api.direct4b.com/albero-app-server/api"
+    , directWaitCreateMessageHandler = True
     }
 
 ----------------------------------------------------------------
 
 -- | Logging in the Direct cloud.
 login
-    :: Config
+    :: Config -- ^ The configuration. NOTE: 'directCreateMessageHandler' and 'directWaitCreateMessageHandler' are ignored.
     -> T.Text -- ^ Login email address for direct.
     -> T.Text -- ^ Login password for direct.
     -> IO (Either Exception LoginInfo) -- ^ This should be passed to 'withClient'.
@@ -140,7 +149,7 @@ withClient config pInfo action = do
                         _ -> return ()
         , RPC.logger             = directLogger config
         , RPC.formatter          = directFormatter config
-        , RPC.waitRequestHandler = True
+        , RPC.waitRequestHandler = directWaitCreateMessageHandler config
         }
 
 subscribeNotification :: Client -> User -> IO ()


### PR DESCRIPTION
Problem
====

`direct4b send` command doesn't stop even after finishing to send a message to direct.

Solution
====

Add `directWaitCreateMessageHandler` to `Config` to change `RPC.waitRequestHandler` by the library users.

NOTE
===

`direct4b upload` has the same problem.
So I'm gonna fix after merging https://github.com/iij-ii/direct-hs/pull/42.