### PR TITLE
🆕 Add `clientCurrentDomain` to `Client`

### DIFF
--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -214,13 +214,13 @@ uploadFile
 uploadFile mtxt mmime mdid tid path = do
     pInfo <- dieWhenLeft . D.deserializeLoginInfo =<< B.readFile jsonFileName
     (EndpointUrl url) <- dieWhenLeft =<< decodeEnv
-    let config = D.defaultConfig { D.directEndpointUrl              = url
+    let config = D.defaultConfig { D.directEndpointUrl     = url
+                                 , D.directInitialDomainId = mdid
                                  , D.directWaitCreateMessageHandler = False
                                  }
     D.withClient config pInfo $ \client -> do
-        did <- (`fromMaybe` mdid) . D.domainId . head <$> D.getDomains client
         upf <- D.readToUpload
             mtxt
             (fromMaybe (TE.decodeUtf8 $ defaultMimeLookup $ T.pack path) mmime)
             path
-        void (either E.throwIO return =<< D.uploadFile client upf did tid)
+        void (either E.throwIO return =<< D.uploadFile client upf tid)

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -72,12 +72,8 @@ where
 
 import           Web.Direct.Api
 import           Web.Direct.Client
-import           Web.Direct.DirectRPC hiding (getDomains)
 import           Web.Direct.Exception
 import           Web.Direct.LoginInfo
 import           Web.Direct.Message
 import           Web.Direct.Types
 import           Web.Direct.Upload
-
-createPair :: Client -> User -> IO TalkRoom
-createPair client = createPairTalk (clientRpcClient client)

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -106,9 +106,8 @@ getTalkStatuses :: RPC.Client -> IO ()
 getTalkStatuses rpcclient =
     void $ callRpcThrow rpcclient "get_talk_statuses" []
 
-createPairTalk :: RPC.Client -> User -> IO TalkRoom
-createPairTalk rpcclient peer = do
-    dom : _ <- getDomains rpcclient
+createPairTalk :: RPC.Client -> Domain -> User -> IO TalkRoom
+createPairTalk rpcclient dom peer = do
     let methodName = "create_pair_talk"
         did        = domainId dom
         uid        = userId peer
@@ -121,15 +120,15 @@ createUploadAuth
     -> Text
     -> Text
     -> FileSize
-    -> DomainId
+    -> Domain
     -> IO (Either Exception UploadAuth)
-createUploadAuth rpcclient fn mimeType fileSize did = do
+createUploadAuth rpcclient fn mimeType fileSize dom = do
     let methodName = "create_upload_auth"
         obj =
             [ M.ObjectStr fn
             , M.ObjectStr mimeType
             , M.ObjectWord fileSize
-            , M.ObjectWord did
+            , M.ObjectWord $ domainId dom
             ]
     eres <- callRpc rpcclient methodName obj
     case eres of


### PR DESCRIPTION
Problem
=====

It's cumbersome for the library users to specify domain ID to
use some APIs.
Before this commit, `createPairTalk` implicitly calls `getDomains`
to obtain all domains the logged-in user belongs to, then choose
the first domain's ID from the result.

But there're several problems in this way:

- If the logged-in user belongs to several domains, `createPairTalk`
  can try to make a pair talk with user who doesn't belong to the
  domain, which would cause an error.
- Calling `getDomains` every time is inefficient.

Solution
====

- Add `clientCurrentDomain :: Domain` to `Client` with its getter
  and setter.
    - Used for some RPC functions which requires a domain ID for
      its argument (e.g. `createPairTalk`, `createUploadAuth`).
    - Can be updated with `setCurrentDomain` if required.
- Add `directInitialDomainId :: Maybe DomainId` to `Config`
  for the library users to specify the domain ID by themselves.
    - If `Nothing` (by default), `withClient` calls `getDomains`
      to obtain all domains the logged-in user belongs to, then choose
      the first domain's ID from the result.
      It's just like `createPairTalk` before this commit does.
      And it **frees the library users from specifying a domain ID
      every time, as well as enable them to customize a domain ID!**