### PR TITLE
[RFC] Make sender user and talk room available with Channel

### DIFF
--- a/direct-hs-examples/src/nippo.hs
+++ b/direct-hs-examples/src/nippo.hs
@@ -23,9 +23,8 @@ main = do
         pInfo
         body
   where
-    body client =
-        S.installHandler S.sigTERM $ \_ ->
-            D.shutdown client $ D.Txt "BOTが終了します。\nこの作業は後からやり直してください。"
+    body client = S.installHandler S.sigTERM
+        $ \_ -> D.shutdown client $ D.Txt "BOTが終了します。\nこの作業は後からやり直してください。"
 
 handleCreateMessage
     :: D.Client -> (D.Message, D.MessageId, D.TalkRoom, D.User) -> IO ()

--- a/direct-hs-examples/src/nippo.hs
+++ b/direct-hs-examples/src/nippo.hs
@@ -23,7 +23,7 @@ main = do
         pInfo
         body
   where
-    body client = do
+    body client =
         S.installHandler S.sigTERM $ \_ ->
             D.shutdown client $ D.Txt "BOTが終了します。\nこの作業は後からやり直してください。"
 
@@ -46,7 +46,7 @@ nippo peer chan = do
                     `T.append` "さん、\nお疲れ様です。\n今日はどんな業務をしましたか？\n1件1メッセージでお願いします。"
         void $ D.send chan (D.Txt msg)
     askJobs jobs = do
-        (msg, _msgid) <- D.recv chan
+        (msg, _msgid, _room, _user) <- D.recv chan
         case msg of
             D.Txt "。" -> return jobs
             D.Txt job -> do
@@ -64,7 +64,7 @@ nippo peer chan = do
         recvLoop
       where
         recvLoop = do
-            (msg, _aux) <- D.recv chan
+            (msg, _msgid, _room, _user) <- D.recv chan
             case msg of
                 D.SelectA _ _ ans -> return ans
                 _                 -> do

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -134,21 +134,22 @@ withClient config pInfo action = do
                             Just (msg, msgid, tid, uid)
                                 | uid /= myid && uid /= 0 -> do
                                     mchan <- findChannel client (tid, Just uid)
-                                    Just user <- findUser
-                                        uid
-                                        client
-                                    Just room <- findTalkRoom
-                                        tid
-                                        client
+                                    Just user <- findUser uid client
+                                    Just room <- findTalkRoom tid client
                                     case mchan of
-                                        Just chan -> dispatch chan msg msgid room user
-                                        Nothing   -> do
+                                        Just chan ->
+                                            dispatch chan msg msgid room user
+                                        Nothing -> do
                                             mchan' <- findChannel
                                                 client
                                                 (tid, Nothing)
                                             case mchan' of
-                                                Just chan' ->
-                                                    dispatch chan' msg msgid room user
+                                                Just chan' -> dispatch
+                                                    chan'
+                                                    msg
+                                                    msgid
+                                                    room
+                                                    user
                                                 Nothing ->
                                                     directCreateMessageHandler
                                                         config

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -134,22 +134,22 @@ withClient config pInfo action = do
                             Just (msg, msgid, tid, uid)
                                 | uid /= myid && uid /= 0 -> do
                                     mchan <- findChannel client (tid, Just uid)
+                                    Just user <- findUser
+                                        uid
+                                        client
+                                    Just room <- findTalkRoom
+                                        tid
+                                        client
                                     case mchan of
-                                        Just chan -> dispatch chan msg msgid
+                                        Just chan -> dispatch chan msg msgid room user
                                         Nothing   -> do
                                             mchan' <- findChannel
                                                 client
                                                 (tid, Nothing)
                                             case mchan' of
                                                 Just chan' ->
-                                                    dispatch chan' msg msgid
-                                                Nothing -> do
-                                                    Just user <- findUser
-                                                        uid
-                                                        client
-                                                    Just room <- findTalkRoom
-                                                        tid
-                                                        client
+                                                    dispatch chan' msg msgid room user
+                                                Nothing ->
                                                     directCreateMessageHandler
                                                         config
                                                         client

--- a/direct-hs/src/Web/Direct/Client/Channel/Types.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel/Types.hs
@@ -30,7 +30,7 @@ import           Web.Direct.Types
 
 -- | A virtual communication channel.
 data Channel = Channel {
-      toWorker         :: C.MVar (Either Control (Message, MessageId))
+      toWorker         :: C.MVar (Either Control (Message, MessageId, TalkRoom, User))
     , channelRPCClient :: RPC.Client
     , channelType      :: ChannelType
     , channelKey       :: ChannelKey
@@ -56,8 +56,8 @@ newChannel rpcclient ctyp ckey room = do
 
 ----------------------------------------------------------------
 
-dispatch :: Channel -> Message -> MessageId -> IO ()
-dispatch chan msg mid = C.putMVar (toWorker chan) $ Right (msg, mid)
+dispatch :: Channel -> Message -> MessageId -> TalkRoom -> User -> IO ()
+dispatch chan msg mid room user = C.putMVar (toWorker chan) $ Right (msg, mid, room, user)
 
 newtype Control = Die Message
 
@@ -68,7 +68,7 @@ die :: Message -> Channel -> IO ()
 die msg chan = control chan (Die msg)
 
 -- | Receiving a message from the channel.
-recv :: Channel -> IO (Message, MessageId)
+recv :: Channel -> IO (Message, MessageId, TalkRoom, User)
 recv chan = do
     cm <- C.takeMVar $ toWorker chan
     case cm of

--- a/direct-hs/src/Web/Direct/Client/Channel/Types.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel/Types.hs
@@ -57,7 +57,8 @@ newChannel rpcclient ctyp ckey room = do
 ----------------------------------------------------------------
 
 dispatch :: Channel -> Message -> MessageId -> TalkRoom -> User -> IO ()
-dispatch chan msg mid room user = C.putMVar (toWorker chan) $ Right (msg, mid, room, user)
+dispatch chan msg mid room user =
+    C.putMVar (toWorker chan) $ Right (msg, mid, room, user)
 
 newtype Control = Die Message
 


### PR DESCRIPTION
Problem
====

Messages got from `recv` function doesn't have their sender users' ID and name.
This makes it impossible to create a bot which collects users' information in a `GroupTalk`
(e.g. a survey bot which can count users' answers in a `GroupTalk`).

Solution
====

Add `TalkRoom` and `User` to the return value of `recv` function
for consistency with the arguments of `directCreateMessageHandler`.

Request for Comments
====

It might be better to make a new (record) type to represent the tuple of
`(Message, MessageId, TalkRoom, User)`, which is transferred by
`directCreateMessageHandler`, `recv`, and `dispatch`.
But I can't make up a good name and a structure.