### PR TITLE
Support multi domains

### DIFF
--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -2,7 +2,7 @@
 
 import           Control.Applicative    (optional, (<**>), (<|>))
 import qualified Control.Exception      as E
-import           Control.Monad          (forM_, join, void)
+import           Control.Monad          (forM_, join, void, (>=>))
 import           Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Lazy   as B
 import           Data.List              (intercalate)
@@ -89,6 +89,63 @@ main = join $ Opt.execParser optionsInfo
                        )
                        (Opt.fullDesc <> Opt.progDesc
                            "Send a message from stdin as the logged-in user."
+                       )
+                   )
+            <> Opt.command
+                   "get"
+                   (Opt.info
+                       (    Opt.subparser
+                               (  Opt.command
+                                     "all"
+                                     (Opt.info
+                                         (pure printAll <**> Opt.helper)
+                                         Opt.briefDesc
+                                     )
+                               <> Opt.command
+                                      "domains"
+                                      (Opt.info
+                                          (pure printDomains <**> Opt.helper)
+                                          Opt.briefDesc
+                                      )
+                               <> Opt.command
+                                      "users"
+                                      (Opt.info
+                                          (    printUsers
+                                          <$>  optional
+                                                   (Opt.option
+                                                       Opt.auto
+                                                       (  Opt.short 'd'
+                                                       <> Opt.metavar
+                                                              "DOMAIN_ID"
+                                                       )
+                                                   )
+                                          <**> Opt.helper
+                                          )
+                                          Opt.briefDesc
+                                      )
+                               <> Opt.command
+                                      "talks"
+                                      (Opt.info
+                                          (    printTalkRooms
+                                          <$>  optional
+                                                   (Opt.option
+                                                       Opt.auto
+                                                       (  Opt.short 'd'
+                                                       <> Opt.metavar
+                                                              "DOMAIN_ID"
+                                                       )
+                                                   )
+                                          <**> Opt.helper
+                                          )
+                                          Opt.briefDesc
+                                      )
+                               )
+                       <**> Opt.helper
+                       )
+                       (  Opt.fullDesc
+                       <> Opt.progDesc
+                              "Display information on the logged-in user."
+                       <> Opt.header ""
                        )
                    )
 
@@ -224,3 +281,76 @@ uploadFile mtxt mmime mdid tid path = do
             (fromMaybe (TE.decodeUtf8 $ defaultMimeLookup $ T.pack path) mmime)
             path
         void (either E.throwIO return =<< D.uploadFile client upf tid)
+
+
+printAll :: IO ()
+printAll = do
+    pInfo <- dieWhenLeft . D.deserializeLoginInfo =<< B.readFile jsonFileName
+    (EndpointUrl url) <- dieWhenLeft =<< decodeEnv
+    let config = D.defaultConfig { D.directEndpointUrl              = url
+                                 , D.directWaitCreateMessageHandler = False
+                                 }
+    D.withClient config pInfo $ \client -> do
+        domains <- D.getDomains client
+        forM_ domains $ \domain -> do
+            void $ D.setCurrentDomain client domain
+            putStrLn "# Domain"
+            putStrLn $ showDomain domain
+            putStrLn "# Users"
+            D.getUsers client >>= mapM_ (putStrLn . showUser)
+            putStrLn "# TalkRooms"
+            D.getTalkRooms client >>= mapM_ (putStrLn . showTalkRoom)
+            putStrLn ""
+
+printDomains :: IO ()
+printDomains = do
+    pInfo <- dieWhenLeft . D.deserializeLoginInfo =<< B.readFile jsonFileName
+    (EndpointUrl url) <- dieWhenLeft =<< decodeEnv
+    let config = D.defaultConfig { D.directEndpointUrl              = url
+                                 , D.directWaitCreateMessageHandler = False
+                                 }
+    D.withClient config pInfo $ D.getDomains >=> mapM_ (putStrLn . showDomain)
+
+printUsers :: Maybe D.DomainId -> IO ()
+printUsers mdid = do
+    pInfo <- dieWhenLeft . D.deserializeLoginInfo =<< B.readFile jsonFileName
+    (EndpointUrl url) <- dieWhenLeft =<< decodeEnv
+    let config = D.defaultConfig { D.directEndpointUrl              = url
+                                 , D.directInitialDomainId          = mdid
+                                 , D.directWaitCreateMessageHandler = False
+                                 }
+    D.withClient config pInfo $ D.getUsers >=> mapM_ (putStrLn . showUser)
+
+printTalkRooms :: Maybe D.DomainId -> IO ()
+printTalkRooms mdid = do
+    pInfo <- dieWhenLeft . D.deserializeLoginInfo =<< B.readFile jsonFileName
+    (EndpointUrl url) <- dieWhenLeft =<< decodeEnv
+    let config = D.defaultConfig { D.directEndpointUrl              = url
+                                 , D.directInitialDomainId          = mdid
+                                 , D.directWaitCreateMessageHandler = False
+                                 }
+    D.withClient config pInfo $ D.getTalkRooms >=> mapM_
+        (putStrLn . showTalkRoom)
+
+showDomain :: D.Domain -> String
+showDomain domain =
+    intercalate "\t" [show (D.domainId domain), T.unpack (D.domainName domain)]
+
+showUser :: D.User -> String
+showUser user = intercalate
+    "\t"
+    [ show (D.userId user)
+    , T.unpack (D.displayName user)
+    , T.unpack (D.phoneticDisplayName user)
+    ]
+
+showTalkRoom :: D.TalkRoom -> String
+showTalkRoom talkRoom = intercalate
+    "\t"
+    [ show (D.talkId talkRoom)
+    , showTalkType (D.talkType talkRoom)
+    , intercalate ", " $ map (T.unpack . D.displayName) (D.talkUsers talkRoom)
+    ]
+  where
+    showTalkType (D.GroupTalk name) = "GroupTalk \"" ++ T.unpack name ++ "\""
+    showTalkType other              = show other

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -96,12 +96,6 @@ main = join $ Opt.execParser optionsInfo
                    (Opt.info
                        (    Opt.subparser
                                (  Opt.command
-                                     "all"
-                                     (Opt.info
-                                         (pure printAll <**> Opt.helper)
-                                         Opt.briefDesc
-                                     )
-                               <> Opt.command
                                       "domains"
                                       (Opt.info
                                           (pure printDomains <**> Opt.helper)
@@ -282,25 +276,6 @@ uploadFile mtxt mmime mdid tid path = do
             path
         void (either E.throwIO return =<< D.uploadFile client upf tid)
 
-
-printAll :: IO ()
-printAll = do
-    pInfo <- dieWhenLeft . D.deserializeLoginInfo =<< B.readFile jsonFileName
-    (EndpointUrl url) <- dieWhenLeft =<< decodeEnv
-    let config = D.defaultConfig { D.directEndpointUrl              = url
-                                 , D.directWaitCreateMessageHandler = False
-                                 }
-    D.withClient config pInfo $ \client -> do
-        domains <- D.getDomains client
-        forM_ domains $ \domain -> do
-            void $ D.setCurrentDomain client domain
-            putStrLn "# Domain"
-            putStrLn $ showDomain domain
-            putStrLn "# Users"
-            D.getUsers client >>= mapM_ (putStrLn . showUser)
-            putStrLn "# TalkRooms"
-            D.getTalkRooms client >>= mapM_ (putStrLn . showTalkRoom)
-            putStrLn ""
 
 printDomains :: IO ()
 printDomains = do

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -18,6 +18,8 @@ module Web.Direct
     , getTalkRooms
     , getMe
     , getUsers
+    , getCurrentDomain
+    , setCurrentDomain
   -- * Message
   -- ** Ids
     , DomainId

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -19,7 +19,6 @@ module Web.Direct
     , getMe
     , getUsers
     , getCurrentDomain
-    , setCurrentDomain
   -- * Message
   -- ** Ids
     , DomainId

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -12,7 +12,6 @@ where
 import           Control.Monad                            (when)
 import qualified Data.IORef                               as I
 import qualified Data.List                                as L
-import           Data.Maybe                               (fromMaybe)
 import qualified Data.MessagePack                         as M
 import qualified Data.MessagePack.RPC                     as R
 import qualified Data.Text                                as T
@@ -186,14 +185,9 @@ subscribeNotification client me = do
     getAnnouncementStatuses rpcclient
     getFriends rpcclient
 
-    let did = domainId $ getCurrentDomain client
-    acquaintances <- getAcquaintances rpcclient
-    let users0 = fromMaybe [] $ lookup did acquaintances
-    let users = me : (me `L.delete` users0)
+    users <- retrieveUsers client me
     setUsers client users
-    allTalks <- getTalks rpcclient users
-    let talks = fromMaybe [] $ lookup did allTalks
-    setTalkRooms client talks
+    retrieveTalkRooms client users >>= setTalkRooms client
     getTalkStatuses rpcclient
 
 ----------------------------------------------------------------

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -12,6 +12,7 @@ where
 import           Control.Monad                            (when)
 import qualified Data.IORef                               as I
 import qualified Data.List                                as L
+import           Data.Maybe                               (fromMaybe)
 import qualified Data.MessagePack                         as M
 import qualified Data.MessagePack.RPC                     as R
 import qualified Data.Text                                as T
@@ -183,9 +184,14 @@ subscribeNotification client me = do
     getAnnouncementStatuses rpcclient
     getFriends rpcclient
 
-    users <- retrieveUsers client me
+    let did = domainId $ getCurrentDomain client
+    acquaintances <- getAcquaintances rpcclient
+    let users0 = fromMaybe [] $ lookup did acquaintances
+    let users = me : (me `L.delete` users0)
     setUsers client users
-    retrieveTalkRooms client users >>= setTalkRooms client
+    allTalks <- getTalks rpcclient users
+    let talks = fromMaybe [] $ lookup did allTalks
+    setTalkRooms client talks
     getTalkStatuses rpcclient
 
 ----------------------------------------------------------------

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -191,8 +191,9 @@ subscribeNotification client me = do
     let users0 = fromMaybe [] $ lookup did acquaintances
     let users = me : (me `L.delete` users0)
     setUsers client users
-
-    getTalks rpcclient users >>= setTalkRooms client
+    allTalks <- getTalks rpcclient users
+    let talks = fromMaybe [] $ lookup did allTalks
+    setTalkRooms client talks
     getTalkStatuses rpcclient
 
 ----------------------------------------------------------------

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -12,6 +12,7 @@ where
 import           Control.Monad                            (when)
 import qualified Data.IORef                               as I
 import qualified Data.List                                as L
+import           Data.Maybe                               (fromMaybe)
 import qualified Data.MessagePack                         as M
 import qualified Data.MessagePack.RPC                     as R
 import qualified Data.Text                                as T
@@ -185,7 +186,9 @@ subscribeNotification client me = do
     getAnnouncementStatuses rpcclient
     getFriends rpcclient
 
-    users0 <- getAcquaintances rpcclient
+    let did = domainId $ getCurrentDomain client
+    acquaintances <- getAcquaintances rpcclient
+    let users0 = fromMaybe [] $ lookup did acquaintances
     let users = me : (me `L.delete` users0)
     setUsers client users
 

--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -18,6 +18,8 @@ module Web.Direct.Client
     , getUsers
     , getCurrentDomain
     , setCurrentDomain
+    , retrieveUsers
+    , retrieveTalkRooms
     , isActive
     , findUser
     , findTalkRoom
@@ -42,6 +44,7 @@ import           Control.Monad.Except                     (ExceptT (ExceptT),
                                                            runExceptT)
 import qualified Data.IORef                               as I
 import qualified Data.List                                as L
+import           Data.Maybe                               (fromMaybe)
 import qualified Network.MessagePack.RPC.Client.WebSocket as RPC
 
 import           Web.Direct.Client.Channel
@@ -109,8 +112,32 @@ getUsers client = I.readIORef (clientUsers client)
 getCurrentDomain :: Client -> Domain
 getCurrentDomain = clientCurrentDomain
 
-setCurrentDomain :: Client -> Domain -> Client
-setCurrentDomain client did = client { clientCurrentDomain = did }
+setCurrentDomain :: Client -> Domain -> IO Client
+setCurrentDomain client domain = do
+    let client' = client { clientCurrentDomain = domain }
+    someone <- getMe client'
+    case someone of
+        Just me -> do
+            users <- retrieveUsers client' me
+            setUsers client' users
+            retrieveTalkRooms client' users >>= setTalkRooms client
+        Nothing -> fail "Assertion failure: Who am I?"
+    return client'
+
+----------------------------------------------------------------
+
+retrieveUsers :: Client -> User -> IO [User]
+retrieveUsers client me = do
+    acquaintances <- getAcquaintances (clientRpcClient client)
+    let did = domainId $ getCurrentDomain client
+    let users = fromMaybe [] $ lookup did acquaintances
+    return $ me : (me `L.delete` users)
+
+retrieveTalkRooms :: Client -> [User] -> IO [TalkRoom]
+retrieveTalkRooms client users = do
+    talks <- getTalks (clientRpcClient client) users
+    let did = domainId $ getCurrentDomain client
+    return $ fromMaybe [] $ lookup did talks
 
 ----------------------------------------------------------------
 

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -98,7 +98,7 @@ getAcquaintances :: RPC.Client -> IO [(DomainId, [User])]
 getAcquaintances rpcclient =
     fromGetAcquaintances <$> callRpcThrow rpcclient "get_acquaintances" []
 
-getTalks :: RPC.Client -> [User] -> IO [TalkRoom]
+getTalks :: RPC.Client -> [User] -> IO [(DomainId, [TalkRoom])]
 getTalks rpcclient users =
     fromGetTalks users <$> callRpcThrow rpcclient "get_talks" []
 

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -94,7 +94,7 @@ getAnnouncementStatuses rpcclient =
 getFriends :: RPC.Client -> IO ()
 getFriends rpcclient = void $ callRpcThrow rpcclient "get_friends" []
 
-getAcquaintances :: RPC.Client -> IO [User]
+getAcquaintances :: RPC.Client -> IO [(DomainId, [User])]
 getAcquaintances rpcclient =
     fromGetAcquaintances <$> callRpcThrow rpcclient "get_acquaintances" []
 

--- a/direct-hs/src/Web/Direct/DirectRPC/Map.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC/Map.hs
@@ -19,9 +19,12 @@ fromCreateSession (M.ObjectMap m) = do
     decodeUser user
 fromCreateSession _ = Nothing
 
-fromGetAcquaintances :: M.Object -> [User]
-fromGetAcquaintances (M.ObjectArray [M.ObjectArray [M.ObjectWord _domain, M.ObjectArray users]])
-    = mapMaybe decodeUser users
+fromGetAcquaintances :: M.Object -> [(DomainId, [User])]
+fromGetAcquaintances (M.ObjectArray xs) = mapMaybe fromGetAcquaintances' xs
+  where
+    fromGetAcquaintances' (M.ObjectArray [M.ObjectWord _domain, M.ObjectArray users])
+        = Just (_domain, mapMaybe decodeUser users)
+    fromGetAcquaintances' _ = Nothing
 fromGetAcquaintances _ = []
 
 decodeUser :: M.Object -> Maybe User


### PR DESCRIPTION
This PR fixes the behavior of `Web.Direct.getUsers` and `Web.Direct.getTalkRooms` when the loggeed-in user belongs to multiple domains.

## As-Is

- `getUsers` returns just `[me]` regardless of the actual users. (#48)
- `getTalkRooms` returns a list of `TalkRoom` of *all* domains. However, all of their `talkUsers` is just `[me]`.

## To-Be

- `getUsers` returns a list of acquaintances of the *current* domain. The head of the list should be `me`.
- `getTalkRooms` returns a list of `TalkRoom` of the *current* domain. Their `talkUsers` should be a list of all members of the talk.

## TODO

- [x] Fix `getUsers`
- [x] Fix `getTalkRooms`
- ~~[x] Make `Web.Direct.Client.setCurrentDomain` updates `clientUsers` and `clientTalkRooms` of `Client`~~

## `direct4b get`

To check the above fixes, I added `get` sub command to `direct4b` command.

Usage:
```
direct4b get domains       # print domain list
direct4b get users         # print user list of current domain
direct4b get talks         # print talk room list of current domain
```
- `users` and `talks` accept `-d DOMAIN_ID` option.