### PR TITLE
Add `leave` function

### DIFF
--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -51,6 +51,9 @@ module Web.Direct
     , UploadFile(..)
     , readToUpload
     , uploadFile
+  -- * Talk Room
+    , leaveTalkRoom
+    , removeUserFromTalkRoom
   -- * Channel
   -- ** Channel type
     , ChannelType

--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -137,12 +137,8 @@ leaveTalkRoom client tid = runExceptT $ do
     talk <- failWith InvalidTalkId =<< liftIO (findTalkRoom tid client)
     mme  <- liftIO $ getMe client
     case mme of
-        Just me -> do
-            result <- liftIO $ deleteTalker (clientRpcClient client) talk me
-            case result of
-                Right _ -> return ()
-                Left  e -> throwError e
-        _ -> return ()
+        Nothing -> fail "Assertion failure: `getMe` returns `Nothing`"
+        Just me -> ExceptT $ deleteTalker (clientRpcClient client) talk me
 
 removeUserFromTalkRoom :: Client -> TalkId -> UserId -> IO (Either Exception ())
 removeUserFromTalkRoom client tid uid = runExceptT $ do
@@ -151,10 +147,7 @@ removeUserFromTalkRoom client tid uid = runExceptT $ do
     when (talkType talk == PairTalk) $ throwError InvalidTalkType
     user <- failWith InvalidUserId =<< liftIO (findUser uid client)
     when (user `notElem` talkUsers talk) $ throwError InvalidUserId
-    result <- liftIO $ deleteTalker (clientRpcClient client) talk user
-    case result of
-        Right _ -> return ()
-        Left  e -> throwError e
+    ExceptT $ deleteTalker (clientRpcClient client) talk user
 
 ----------------------------------------------------------------
 

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -115,6 +115,14 @@ createPairTalk rpcclient dom peer = do
     rsp <- callRpcThrow rpcclient methodName dat
     convertOrThrow methodName (decodeTalkRoom [peer]) rsp -- fixme: users
 
+deleteTalker :: RPC.Client -> TalkRoom -> User -> IO ()
+deleteTalker rpcclient talk user = do
+    let methodName = "delete_talker"
+        tid        = talkId talk
+        uid        = userId user
+        dat        = [M.ObjectWord tid, M.ObjectWord uid]
+    void $ callRpcThrow rpcclient methodName dat
+
 createUploadAuth
     :: RPC.Client
     -> Text

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -115,13 +115,13 @@ createPairTalk rpcclient dom peer = do
     rsp <- callRpcThrow rpcclient methodName dat
     convertOrThrow methodName (decodeTalkRoom [peer]) rsp -- fixme: users
 
-deleteTalker :: RPC.Client -> TalkRoom -> User -> IO ()
+deleteTalker :: RPC.Client -> TalkRoom -> User -> IO (Either Exception ())
 deleteTalker rpcclient talk user = do
     let methodName = "delete_talker"
         tid        = talkId talk
         uid        = userId user
         dat        = [M.ObjectWord tid, M.ObjectWord uid]
-    void $ callRpcThrow rpcclient methodName dat
+    void <$> callRpc rpcclient methodName dat
 
 createUploadAuth
     :: RPC.Client

--- a/direct-hs/src/Web/Direct/Exception.hs
+++ b/direct-hs/src/Web/Direct/Exception.hs
@@ -22,6 +22,8 @@ import qualified Network.MessagePack.RPC.Client.WebSocket as RPC
 data Exception =
       InvalidEmailOrPassword
     | InvalidTalkId
+    | InvalidTalkType
+    | InvalidUserId
     | InvalidWsUrl !String
     | UnexpectedReponseWhenUpload Status
     | UnexpectedReponse !RPC.MethodName !M.Object


### PR DESCRIPTION
This adds [leave](https://direct4b.com/ja/bot/dev/samples/starter/readme_direct.html#%E3%83%88%E3%83%BC%E3%82%AF%E3%83%AB%E3%83%BC%E3%83%A0%E3%81%8B%E3%82%89%E3%81%AE%E9%80%80%E5%87%BA:7ef1af7b186b8dcff00b423bbbcfa170) function to direct-hs.

The following functions are added to `Web.Direct`.
* `leaveTalkRoom`
  - makes the logged-in user leaving the specified talk room.
  - can be used in both PairTalk and GroupTalk.
* `removeUserFromTalkRoom`
  - makes the specified user leaving the specified talk room.
  - can only be used in GroupTalk due to Direct4B specifications.

In addition, the following commands are added to `direct4b` as an example use of the above.
- `direct4b leave TALK_ID`
- `direct4b ban TALK_ID USER_ID`
