### PR TITLE
Reduce data redundancy

### DIFF
--- a/direct-hs-examples/src/ping.hs
+++ b/direct-hs-examples/src/ping.hs
@@ -39,14 +39,14 @@ handleCreateMessage client (D.Txt "select", _, room, _) = void $ D.sendMessage
 handleCreateMessage client (D.Txt "task", _, room, _) =
     void $ D.sendMessage client (D.TaskQ "高速化できる？" False) (D.talkId room)
 handleCreateMessage client (D.Txt "whoareyou", _, room, _) = do
-    Just me <- D.getMe client
+    me <- D.getMe client
     void $ D.sendMessage
         client
         (D.Txt $ "私は" `T.append` D.displayName me `T.append` "です")
         (D.talkId room)
 handleCreateMessage client (D.Txt "users", _, room, _) = do
     users <- D.getUsers client
-    let ans = T.unlines $ map D.displayName users
+    let ans = T.unlines $ map D.displayName (D.myself users : D.acquaintances users)
     void $ D.sendMessage client (D.Txt (ans `T.append` "がいます。")) (D.talkId room)
 handleCreateMessage client (D.Txt "domains", _, room, _) = do
     doms <- D.getDomains client

--- a/direct-hs-examples/src/ping.hs
+++ b/direct-hs-examples/src/ping.hs
@@ -46,7 +46,7 @@ handleCreateMessage client (D.Txt "whoareyou", _, room, _) = do
         (D.talkId room)
 handleCreateMessage client (D.Txt "users", _, room, _) = do
     users <- D.getUsers client
-    let ans = T.unlines $ map D.displayName (D.usersList users)
+    let ans = T.unlines $ map D.displayName users
     void $ D.sendMessage client (D.Txt (ans `T.append` "がいます。")) (D.talkId room)
 handleCreateMessage client (D.Txt "domains", _, room, _) = do
     doms <- D.getDomains client

--- a/direct-hs-examples/src/ping.hs
+++ b/direct-hs-examples/src/ping.hs
@@ -46,9 +46,7 @@ handleCreateMessage client (D.Txt "whoareyou", _, room, _) = do
         (D.talkId room)
 handleCreateMessage client (D.Txt "users", _, room, _) = do
     users <- D.getUsers client
-    let
-        ans = T.unlines
-            $ map D.displayName (D.myself users : D.acquaintances users)
+    let ans = T.unlines $ map D.displayName (D.usersList users)
     void $ D.sendMessage client (D.Txt (ans `T.append` "がいます。")) (D.talkId room)
 handleCreateMessage client (D.Txt "domains", _, room, _) = do
     doms <- D.getDomains client

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -345,7 +345,7 @@ printUsers mdid = do
                                  }
     D.withClient config pInfo $ \client -> do
         users <- D.getUsers client
-        mapM_ (putStrLn . showUser) (D.myself users : D.acquaintances users)
+        mapM_ (putStrLn . showUser) (D.usersList users)
 
 printTalkRooms :: Maybe D.DomainId -> IO ()
 printTalkRooms mdid = do
@@ -378,10 +378,8 @@ showTalkRoom talk talkUsers = intercalate
     "\t"
     [ show (D.talkId talk)
     , showTalkType (D.talkType talk)
-    , intercalate ", " $ map (T.unpack . D.displayName) (me : talkAcqs)
+    , intercalate ", " $ map (T.unpack . D.displayName) (D.usersList talkUsers)
     ]
   where
     showTalkType (D.GroupTalk name) = "GroupTalk \"" ++ T.unpack name ++ "\""
     showTalkType other              = show other
-    me       = D.myself talkUsers
-    talkAcqs = D.acquaintances talkUsers

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -343,7 +343,9 @@ printUsers mdid = do
                                  , D.directInitialDomainId          = mdid
                                  , D.directWaitCreateMessageHandler = False
                                  }
-    D.withClient config pInfo $ D.getUsers >=> mapM_ (putStrLn . showUser)
+    D.withClient config pInfo $ \client -> do
+        users <- D.getUsers client
+        mapM_ (putStrLn . showUser) (D.myself users : D.acquaintances users)
 
 printTalkRooms :: Maybe D.DomainId -> IO ()
 printTalkRooms mdid = do

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -355,8 +355,11 @@ printTalkRooms mdid = do
                                  , D.directInitialDomainId          = mdid
                                  , D.directWaitCreateMessageHandler = False
                                  }
-    D.withClient config pInfo $ D.getTalkRooms >=> mapM_
-        (putStrLn . showTalkRoom)
+    D.withClient config pInfo $ \client -> do
+        talks <- D.getTalkRooms client
+        forM_ talks $ \talk -> do
+            talkUsers <- D.getTalkUsers client talk
+            putStrLn $ showTalkRoom talk talkUsers
 
 showDomain :: D.Domain -> String
 showDomain domain =
@@ -370,13 +373,15 @@ showUser user = intercalate
     , T.unpack (D.phoneticDisplayName user)
     ]
 
-showTalkRoom :: D.TalkRoom -> String
-showTalkRoom talkRoom = intercalate
+showTalkRoom :: D.TalkRoom -> D.Users -> String
+showTalkRoom talk talkUsers = intercalate
     "\t"
-    [ show (D.talkId talkRoom)
-    , showTalkType (D.talkType talkRoom)
-    , intercalate ", " $ map (T.unpack . D.displayName) (D.talkUsers talkRoom)
+    [ show (D.talkId talk)
+    , showTalkType (D.talkType talk)
+    , intercalate ", " $ map (T.unpack . D.displayName) (me : talkAcqs)
     ]
   where
     showTalkType (D.GroupTalk name) = "GroupTalk \"" ++ T.unpack name ++ "\""
     showTalkType other              = show other
+    me       = D.myself talkUsers
+    talkAcqs = D.acquaintances talkUsers

--- a/direct-hs/app/direct4b.hs
+++ b/direct-hs/app/direct4b.hs
@@ -343,9 +343,7 @@ printUsers mdid = do
                                  , D.directInitialDomainId          = mdid
                                  , D.directWaitCreateMessageHandler = False
                                  }
-    D.withClient config pInfo $ \client -> do
-        users <- D.getUsers client
-        mapM_ (putStrLn . showUser) (D.usersList users)
+    D.withClient config pInfo $ D.getUsers >=> mapM_ (putStrLn . showUser)
 
 printTalkRooms :: Maybe D.DomainId -> IO ()
 printTalkRooms mdid = do
@@ -373,12 +371,12 @@ showUser user = intercalate
     , T.unpack (D.phoneticDisplayName user)
     ]
 
-showTalkRoom :: D.TalkRoom -> D.Users -> String
+showTalkRoom :: D.TalkRoom -> [D.User] -> String
 showTalkRoom talk talkUsers = intercalate
     "\t"
     [ show (D.talkId talk)
     , showTalkType (D.talkType talk)
-    , intercalate ", " $ map (T.unpack . D.displayName) (D.usersList talkUsers)
+    , intercalate ", " $ map (T.unpack . D.displayName) talkUsers
     ]
   where
     showTalkType (D.GroupTalk name) = "GroupTalk \"" ++ T.unpack name ++ "\""

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -43,11 +43,6 @@ module Web.Direct
     , canonicalDisplayName
     , phoneticDisplayName
     , canonicalPhoneticDisplayName
-  -- *** Users
-    , Users
-    , myself
-    , acquaintances
-    , usersList
   -- ** Message
     , Message(..)
   -- * Sending

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -63,7 +63,6 @@ module Web.Direct
   -- ** Creating channel
     , Channel
     , withChannel
-    , channelTalkRoom
   -- ** Channel IO
     , recv
     , send

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -47,6 +47,7 @@ module Web.Direct
     , Users
     , myself
     , acquaintances
+    , usersList
   -- ** Message
     , Message(..)
   -- * Sending

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -19,6 +19,7 @@ module Web.Direct
     , getMe
     , getUsers
     , getCurrentDomain
+    , getTalkUsers
   -- * Message
   -- ** Ids
     , DomainId
@@ -33,7 +34,6 @@ module Web.Direct
   -- *** Talk room
     , TalkRoom
     , talkId
-    , talkUsers
     , talkType
     , TalkType(..)
   -- *** User

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -43,6 +43,10 @@ module Web.Direct
     , canonicalDisplayName
     , phoneticDisplayName
     , canonicalPhoneticDisplayName
+  -- *** Users
+    , Users
+    , myself
+    , acquaintances
   -- ** Message
     , Message(..)
   -- * Sending

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -189,8 +189,7 @@ subscribeNotification client = do
     allAcqs <- getAcquaintances rpcclient
     let acqs = fromMaybe [] $ lookup did allAcqs
     setAcquaintances client acqs
-    me       <- getMe client
-    allTalks <- getTalks rpcclient (me : acqs)
+    allTalks <- getTalks rpcclient
     let talks = fromMaybe [] $ lookup did allTalks
     setTalkRooms client talks
     getTalkStatuses rpcclient

--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -30,7 +30,6 @@ module Web.Direct.Client
     , dispatch
     , ChannelType
     , Channel
-    , channelTalkRoom
     , pairChannel
     , pinPointChannel
     , groupChannel

--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -139,7 +139,7 @@ setCurrentDomain client did = client { clientCurrentDomain = did }
 findUser :: UserId -> Client -> IO (Maybe User)
 findUser uid client = do
     users <- getUsers client
-    return $ L.find (\u -> userId u == uid) (myself users : acquaintances users)
+    return $ L.find (\u -> userId u == uid) (usersList users)
 
 findTalkRoom :: TalkId -> Client -> IO (Maybe TalkRoom)
 findTalkRoom tid client = do

--- a/direct-hs/src/Web/Direct/Client/Channel.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel.hs
@@ -6,7 +6,6 @@ module Web.Direct.Client.Channel
     , findChannel'
     -- re-exporting
     , Channel
-    , channelTalkRoom
     , send
     , recv
     , ChannelType
@@ -56,7 +55,7 @@ allocateChannel rpcclient dom chanDB tvar ctyp = do
         PinPoint room user -> return (room, Just user)
         Group room         -> return (room, Nothing)
     let ckey = (talkId room, userId <$> muser)
-    chan <- newChannel rpcclient ctyp ckey room
+    chan <- newChannel rpcclient ctyp ckey
     S.atomically $ do
         active <- isActiveSTM tvar
         if active

--- a/direct-hs/src/Web/Direct/Client/Channel/Types.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel/Types.hs
@@ -1,7 +1,6 @@
 module Web.Direct.Client.Channel.Types
     ( Channel
     , channelTalkId
-    , channelTalkRoom
     , newChannel
     , dispatch
     , die
@@ -34,7 +33,6 @@ data Channel = Channel {
     , channelRPCClient :: RPC.Client
     , channelType      :: ChannelType
     , channelKey       :: ChannelKey
-    , channelTalkRoom  :: TalkRoom -- ^ Getting the talk room associated with this channel.
     }
 
 channelTalkId :: Channel -> TalkId
@@ -43,15 +41,14 @@ channelTalkId = fst . channelKey
 ----------------------------------------------------------------
 
 -- | Creating a new channel.
-newChannel :: RPC.Client -> ChannelType -> ChannelKey -> TalkRoom -> IO Channel
-newChannel rpcclient ctyp ckey room = do
+newChannel :: RPC.Client -> ChannelType -> ChannelKey -> IO Channel
+newChannel rpcclient ctyp ckey = do
     mvar <- C.newEmptyMVar
     return Channel
         { toWorker         = mvar
         , channelRPCClient = rpcclient
         , channelType      = ctyp
         , channelKey       = ckey
-        , channelTalkRoom  = room
         }
 
 ----------------------------------------------------------------

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -98,9 +98,8 @@ getAcquaintances :: RPC.Client -> IO [(DomainId, [User])]
 getAcquaintances rpcclient =
     fromGetAcquaintances <$> callRpcThrow rpcclient "get_acquaintances" []
 
-getTalks :: RPC.Client -> [User] -> IO [(DomainId, [TalkRoom])]
-getTalks rpcclient users =
-    fromGetTalks users <$> callRpcThrow rpcclient "get_talks" []
+getTalks :: RPC.Client -> IO [(DomainId, [TalkRoom])]
+getTalks rpcclient = fromGetTalks <$> callRpcThrow rpcclient "get_talks" []
 
 getTalkStatuses :: RPC.Client -> IO ()
 getTalkStatuses rpcclient =
@@ -113,7 +112,7 @@ createPairTalk rpcclient dom peer = do
         uid        = userId peer
         dat        = [M.ObjectWord did, M.ObjectWord uid]
     rsp <- callRpcThrow rpcclient methodName dat
-    convertOrThrow methodName (decodeTalkRoom [peer]) rsp -- fixme: users
+    convertOrThrow methodName decodeTalkRoom rsp
 
 deleteTalker :: RPC.Client -> TalkRoom -> User -> IO (Either Exception ())
 deleteTalker rpcclient talk user = do

--- a/direct-hs/src/Web/Direct/Types.hs
+++ b/direct-hs/src/Web/Direct/Types.hs
@@ -46,9 +46,9 @@ data TalkType = UnknownTalk | PairTalk | GroupTalk !T.Text deriving (Eq, Show)
 
 -- | Type for talk rooms.
 data TalkRoom = TalkRoom {
-    talkId    :: !TalkId
-  , talkType  :: !TalkType
-  , talkUsers :: [User] -- ^ The head of this list is myself.
+    talkId      :: !TalkId
+  , talkType    :: !TalkType
+  , talkUserIds :: [UserId]
   } deriving (Eq, Show)
 
 -- | Created from the response of direct's RPC function @create_upload_auth@.

--- a/direct-hs/src/Web/Direct/Types.hs
+++ b/direct-hs/src/Web/Direct/Types.hs
@@ -35,6 +35,9 @@ data Users = Users {
   , acquaintances :: [User]
 } deriving (Eq, Show)
 
+usersList :: Users -> [User]
+usersList users = myself users : acquaintances users
+
 -- | Type for domains.
 data Domain = Domain {
     domainId   :: !DomainId

--- a/direct-hs/src/Web/Direct/Types.hs
+++ b/direct-hs/src/Web/Direct/Types.hs
@@ -29,6 +29,12 @@ data User = User {
   , canonicalPhoneticDisplayName :: !T.Text
   } deriving (Eq, Show)
 
+-- | Type for user list.
+data Users = Users {
+    myself        :: !User
+  , acquaintances :: [User]
+} deriving (Eq, Show)
+
 -- | Type for domains.
 data Domain = Domain {
     domainId   :: !DomainId

--- a/direct-hs/src/Web/Direct/Types.hs
+++ b/direct-hs/src/Web/Direct/Types.hs
@@ -29,15 +29,6 @@ data User = User {
   , canonicalPhoneticDisplayName :: !T.Text
   } deriving (Eq, Show)
 
--- | Type for user list.
-data Users = Users {
-    myself        :: !User
-  , acquaintances :: [User]
-} deriving (Eq, Show)
-
-usersList :: Users -> [User]
-usersList users = myself users : acquaintances users
-
 -- | Type for domains.
 data Domain = Domain {
     domainId   :: !DomainId


### PR DESCRIPTION
This PR modifies some data types to reduce data redundancy. The purpose of this PR is to make it easy to maintain the integrity of data when handling notifications.

## Changes (UPDATE: see https://github.com/iij-ii/direct-hs/pull/62#issuecomment-440606390)

### Implementation

* :new: `data Users`
    - This is a data type for managing list of `User` instead of just `[User]`.
    - This has two fields:
        - `myself`: `User` for the logged-in user
        - `acquaintances`: `[User]` for other users
* `data Client`
    - `clientMe`: removed
        - Instead, `clientUsers` holds `me` (as `myself`)
    - `clientUsers`: data type changed from `[User]` to `Users`
* `data TalkRoom`
    - `talkUsers`: removed
    - :new: `talkUserIds`: `[UserId]` for talk room members
* `data Channel`
    - `channelTalkRoom`: removed

### Interfaces

|                  | Before                    | After                                |
|------------------|---------------------------|--------------------------------------|
| setUsers         | Client -> [User] -> IO () | Client -> Users -> IO ()             |
| getUsers         | Client -> IO [User]       | Client -> IO Users                   |
| getMe            | Client -> IO (Maybe User) | Client -> IO User                    |
| setAcquaintances | -                         | :new: Client -> [User] -> IO ()      |
| getAcquaintances | -                         | :new: Client -> IO [User]            |
| talkUsers        | TalkRoom -> [User]        | :no_entry: removed                          |
| getTalkUsers     | -                         | :new: Client -> TalkRoom -> IO Users |
| channelTalkRoom  | Channel -> TalkRoom       | :no_entry: removed                          |
