### PR TITLE
Add notification handlers for `notify_delete_talk/talker`

### DIFF
--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -5,6 +5,7 @@ module Web.Direct.Client
     ( Client
     , clientRpcClient
     , clientLoginInfo
+    , clientChannels
     , sendMessage
     , uploadFile
     , newClient
@@ -36,6 +37,8 @@ module Web.Direct.Client
     , pairChannel
     , pinPointChannel
     , groupChannel
+    , haltChannel
+    , getChannels
     , send
     , recv
     )

--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -27,6 +27,7 @@ module Web.Direct.Client
     , removeUserFromTalkRoom
     , findChannel
     , withChannel
+    , getChannelAcquaintances
     , shutdown
     -- re-exporting
     , dispatch
@@ -216,6 +217,12 @@ withChannel client ctyp body = withChannel' (clientRpcClient client)
                                             (clientStatus client)
                                             ctyp
                                             body
+
+getChannelAcquaintances :: Client -> Channel -> IO [User]
+getChannelAcquaintances client chan = case channelType chan of
+    (Pair user      ) -> return [user]
+    (PinPoint _ user) -> return [user]
+    (Group talk     ) -> getTalkAcquaintances client talk
 
 -- | This function lets 'directCreateMessageHandler' to not accept any message,
 --   then sends the maintenance message to all channels,

--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -11,6 +11,7 @@ module Web.Direct.Client
     , newClient
     , setDomains
     , getDomains
+    , modifyTalkRooms
     , setTalkRooms
     , getTalkRooms
     , setMe
@@ -100,6 +101,9 @@ setDomains client domains = I.writeIORef (clientDomains client) domains
 
 getDomains :: Client -> IO [Domain]
 getDomains client = I.readIORef (clientDomains client)
+
+modifyTalkRooms :: Client -> ([TalkRoom] -> ([TalkRoom], ())) -> IO ()
+modifyTalkRooms client = I.atomicModifyIORef' (clientTalkRooms client)
 
 setTalkRooms :: Client -> [TalkRoom] -> IO ()
 setTalkRooms client talks = I.writeIORef (clientTalkRooms client) talks

--- a/direct-hs/src/Web/Direct/Client/Channel.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel.hs
@@ -2,6 +2,7 @@ module Web.Direct.Client.Channel
     ( withChannel'
     , ChannelDB
     , newChannelDB
+    , haltChannel
     , shutdown'
     , findChannel'
     -- re-exporting
@@ -67,6 +68,11 @@ allocateChannel rpcclient dom chanDB tvar ctyp = do
 freeChannel :: ChannelDB -> Channel -> IO ()
 freeChannel chanDB chan = S.atomically $ S.modifyTVar' chanDB $ HM.delete key
     where key = channelKey chan
+
+haltChannel :: ChannelDB -> Channel -> IO ()
+haltChannel chanDB chan = do
+    die Nothing chan
+    freeChannel chanDB chan
 
 allChannels :: ChannelDB -> IO [Channel]
 allChannels chanDB = HM.elems <$> S.atomically (S.readTVar chanDB)

--- a/direct-hs/src/Web/Direct/Client/Channel.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel.hs
@@ -8,9 +8,10 @@ module Web.Direct.Client.Channel
     , findChannel'
     -- re-exporting
     , Channel
+    , channelType
     , send
     , recv
-    , ChannelType
+    , ChannelType(..)
     , pairChannel
     , pinPointChannel
     , groupChannel

--- a/direct-hs/src/Web/Direct/Client/Channel.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel.hs
@@ -4,6 +4,7 @@ module Web.Direct.Client.Channel
     , newChannelDB
     , haltChannel
     , shutdown'
+    , getChannels
     , findChannel'
     -- re-exporting
     , Channel
@@ -76,6 +77,10 @@ haltChannel chanDB chan = do
 
 allChannels :: ChannelDB -> IO [Channel]
 allChannels chanDB = HM.elems <$> S.atomically (S.readTVar chanDB)
+
+getChannels :: ChannelDB -> TalkId -> IO [Channel]
+getChannels chanDB tid =
+    filter ((tid ==) . channelTalkId) <$> allChannels chanDB
 
 findChannel' :: ChannelDB -> ChannelKey -> IO (Maybe Channel)
 findChannel' chanDB key = HM.lookup key <$> S.atomically (S.readTVar chanDB)

--- a/direct-hs/src/Web/Direct/Client/Channel.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel.hs
@@ -107,6 +107,6 @@ shutdown' :: RPC.Client -> ChannelDB -> StatusVar -> Message -> IO ()
 shutdown' rpcclient chanDB tvar msg = do
     inactivate tvar
     chans <- allChannels chanDB
-    mapM_ (die msg) chans
+    mapM_ (die $ Just msg) chans
     wait chanDB
     RPC.shutdown rpcclient

--- a/direct-hs/src/Web/Direct/Client/Channel/Types.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel/Types.hs
@@ -1,5 +1,6 @@
 module Web.Direct.Client.Channel.Types
     ( Channel
+    , channelType
     , channelTalkId
     , newChannel
     , dispatch

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -4,6 +4,7 @@ module Web.Direct.DirectRPC where
 
 import           Control.Monad                            (void)
 import qualified Data.MessagePack                         as M
+import qualified Data.MessagePack.RPC                     as R
 import           Data.Text                                (Text)
 import qualified Network.MessagePack.RPC.Client.WebSocket as RPC
 
@@ -144,3 +145,16 @@ createUploadAuth rpcclient fn mimeType fileSize dom = do
             _       -> return $ Left $ UnexpectedReponse methodName rsp
         Right other -> return $ Left $ UnexpectedReponse methodName other
         Left  e     -> return $ Left e
+
+----------------------------------------------------------------
+
+data NotificationHandlers = NotificationHandlers
+    { onNotifyDeleteTalk :: TalkId -> IO ()
+    }
+
+handleNotification
+    :: R.MethodName -> [M.Object] -> NotificationHandlers -> IO ()
+handleNotification method params handlers = case (method, params) of
+    ("notify_delete_talk", M.ObjectWord tid : _) ->
+        onNotifyDeleteTalk handlers tid
+    _ -> return ()

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -150,6 +150,7 @@ createUploadAuth rpcclient fn mimeType fileSize dom = do
 
 data NotificationHandlers = NotificationHandlers
     { onNotifyDeleteTalk :: TalkId -> IO ()
+    , onNotifyDeleteTalker :: DomainId -> TalkId -> [UserId] -> [UserId] -> IO ()
     }
 
 handleNotification
@@ -157,4 +158,8 @@ handleNotification
 handleNotification method params handlers = case (method, params) of
     ("notify_delete_talk", M.ObjectWord tid : _) ->
         onNotifyDeleteTalk handlers tid
+    ("notify_delete_talker", obj : _) -> case decodeTalker obj of
+        Just (did, tid, uids, leftUids) ->
+            onNotifyDeleteTalker handlers did tid uids leftUids
+        _ -> return ()
     _ -> return ()

--- a/direct-hs/src/Web/Direct/DirectRPC/Map.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC/Map.hs
@@ -94,3 +94,30 @@ decodeUploadAuth rspMap = do
         (M.ObjectStr "Content-Disposition")
         formObj
     return UploadAuth {..}
+
+----------------------------------------------------------------
+
+decodeTalker :: M.Object -> Maybe (DomainId, TalkId, [UserId], [UserId])
+decodeTalker (M.ObjectMap m) = do
+    M.ObjectWord did <- look "domain_id" m
+    M.ObjectWord tid <- look "talk_id" m
+    userIds          <- decodeUserIds =<< look "user_ids" m
+    leftUsers        <- decodeLeftUsers =<< look "left_users" m
+    return (did, tid, userIds, leftUsers)
+decodeTalker _ = Nothing
+
+decodeUserIds :: M.Object -> Maybe [UserId]
+decodeUserIds (M.ObjectArray arr) = Just $ mapMaybe decodeUserId arr
+  where
+    decodeUserId (M.ObjectWord uid) = Just uid
+    decodeUserId _                  = Nothing
+decodeUserIds _ = Nothing
+
+decodeLeftUsers :: M.Object -> Maybe [UserId]
+decodeLeftUsers (M.ObjectArray arr) = Just $ mapMaybe decodeLeftUser arr
+  where
+    decodeLeftUser (M.ObjectMap m) = do
+        M.ObjectWord uid <- look "user_id" m
+        return uid
+    decodeLeftUser _ = Nothing
+decodeLeftUsers _ = Nothing


### PR DESCRIPTION
This PR adds notification handlers for the following notifications.

* `notify_delete_talk`
    - This notification is sent when the logged-in user exits the talk room.
    - Handler TODO:
        - [x] Close `Channel` created on the exited talk room.
        - [x] Remove `TalkRoom` from `clientTalkRooms` of `Client`.

* `notify_delete_talker`
    - This notification is sent when the other user exits the talk room.
    - Handler TODO:
        - [x] Close `Channel` which has no participants as a result of the user exiting.
        - [x] Remove `UserId` of the exited user from `talkUserIds` of `TalkRoom`.
