### PR TITLE
Make a private RPC method removed

### DIFF
--- a/direct-hs-examples/src/nippo.hs
+++ b/direct-hs-examples/src/nippo.hs
@@ -29,7 +29,7 @@ main = do
 handleCreateMessage
     :: D.Client -> (D.Message, D.MessageId, D.TalkRoom, D.User) -> IO ()
 handleCreateMessage client (D.Txt txt, _, room, user) | "報告" `T.isInfixOf` txt =
-    void $ D.withChannel client room (D.Only user) $ nippo user
+    void $ D.withChannel client room (Just user) $ nippo user
 handleCreateMessage _client _ = return ()
 
 nippo :: D.User -> D.Channel -> IO ()

--- a/direct-hs-examples/src/nippo.hs
+++ b/direct-hs-examples/src/nippo.hs
@@ -29,7 +29,7 @@ main = do
 handleCreateMessage
     :: D.Client -> (D.Message, D.MessageId, D.TalkRoom, D.User) -> IO ()
 handleCreateMessage client (D.Txt txt, _, room, user) | "報告" `T.isInfixOf` txt =
-    void $ D.withChannel client (D.pinPointChannel room user) $ nippo user
+    void $ D.withChannel client room (D.Only user) $ nippo user
 handleCreateMessage _client _ = return ()
 
 nippo :: D.User -> D.Channel -> IO ()

--- a/direct-hs/direct-hs.cabal
+++ b/direct-hs/direct-hs.cabal
@@ -16,6 +16,7 @@ library
   hs-source-dirs:  src
   ghc-options:     -Wall
   exposed-modules: Web.Direct
+                   Web.Direct.Internal
   other-modules:   Web.Direct.Api
                    Web.Direct.Client
                    Web.Direct.Client.Channel

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -57,11 +57,7 @@ module Web.Direct
     , leaveTalkRoom
     , removeUserFromTalkRoom
   -- * Channel
-  -- ** Channel type
-    , ChannelType
-    , pairChannel
-    , pinPointChannel
-    , groupChannel
+    , Partner (..)
   -- ** Creating channel
     , Channel
     , withChannel

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -57,8 +57,6 @@ module Web.Direct
     , leaveTalkRoom
     , removeUserFromTalkRoom
   -- * Channel
-  -- ** Channel partner
-    , Partner(..)
   -- ** Creating channel
     , Channel
     , withChannel

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -57,6 +57,7 @@ module Web.Direct
     , leaveTalkRoom
     , removeUserFromTalkRoom
   -- * Channel
+  -- ** Channel partner
     , Partner(..)
   -- ** Creating channel
     , Channel
@@ -66,7 +67,7 @@ module Web.Direct
     , send
   -- * Terminating
     , shutdown
-  -- *Exceptions
+  -- * Exceptions
     , Exception(..)
     )
 where

--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -209,8 +209,8 @@ isActive client = S.atomically $ isActiveSTM $ clientStatus client
 findChannel :: Client -> ChannelKey -> IO (Maybe Channel)
 findChannel client ckey = findChannel' (clientChannels client) ckey
 
--- | A new channel is created according to the first and second arguments.
---   Then the third argument runs in a new thread with the channel.
+-- | A new channel is created according to the first three arguments.
+--   Then the fourth argument runs in a new thread with the channel.
 --   In this case, 'True' is returned.
 --   If 'shutdown' is already called, a new thread is not spawned
 --   and 'False' is returned.

--- a/direct-hs/src/Web/Direct/Client.hs
+++ b/direct-hs/src/Web/Direct/Client.hs
@@ -38,7 +38,6 @@ module Web.Direct.Client
     , getChannels
     , send
     , recv
-    , Partner(..)
     )
 where
 
@@ -214,7 +213,12 @@ findChannel client ckey = findChannel' (clientChannels client) ckey
 --   In this case, 'True' is returned.
 --   If 'shutdown' is already called, a new thread is not spawned
 --   and 'False' is returned.
-withChannel :: Client -> TalkRoom -> Partner -> (Channel -> IO ()) -> IO Bool
+withChannel
+  :: Client
+  -> TalkRoom -- ^ where to talk
+  -> Maybe User -- ^ limit of who to talk with; 'Nothing' means everyone (no limits)
+  -> (Channel -> IO ())
+  -> IO Bool
 withChannel client room partner body = withChannel'
     (clientRpcClient client)
     (clientChannels client)
@@ -224,9 +228,9 @@ withChannel client room partner body = withChannel'
     body
 
 getChannelAcquaintances :: Client -> Channel -> IO [User]
-getChannelAcquaintances client chan = case channelPartner chan of
-    Only user -> return [user]
-    Anyone    -> getTalkAcquaintances client $ channelTalkRoom chan
+getChannelAcquaintances client chan = case channelUserLimit chan of
+    Just user -> return [user]
+    Nothing   -> getTalkAcquaintances client $ channelTalkRoom chan
 
 -- | This function lets 'directCreateMessageHandler' to not accept any message,
 --   then sends the maintenance message to all channels,

--- a/direct-hs/src/Web/Direct/Client/Channel/Types.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel/Types.hs
@@ -7,7 +7,6 @@ module Web.Direct.Client.Channel.Types
     , send
     , recv
     , ChannelKey
-    , Partner(..)
     )
 where
 
@@ -28,7 +27,7 @@ data Channel = Channel {
       toWorker         :: C.MVar (Either Control (Message, MessageId, TalkRoom, User))
     , channelRPCClient :: RPC.Client
     , channelTalkRoom  :: TalkRoom
-    , channelPartner   :: Partner
+    , channelUserLimit :: Maybe User
     , channelKey       :: ChannelKey
     }
 
@@ -38,14 +37,14 @@ channelTalkId = fst . channelKey
 ----------------------------------------------------------------
 
 -- | Creating a new channel.
-newChannel :: RPC.Client -> TalkRoom -> Partner -> ChannelKey -> IO Channel
-newChannel rpcclient room partner ckey = do
+newChannel :: RPC.Client -> TalkRoom -> Maybe User -> ChannelKey -> IO Channel
+newChannel rpcclient room userLimit ckey = do
     mvar <- C.newEmptyMVar
     return Channel
         { toWorker         = mvar
         , channelRPCClient = rpcclient
         , channelTalkRoom  = room
-        , channelPartner   = partner
+        , channelUserLimit = userLimit
         , channelKey       = ckey
         }
 
@@ -83,9 +82,3 @@ send chan msg = createMessage (channelRPCClient chan) msg $ channelTalkId chan
 ----------------------------------------------------------------
 
 type ChannelKey = (TalkId, Maybe UserId)
-
--- | User(s) with whome you want to talk.
-data Partner =
-      Only User
-    | Anyone
-    deriving (Show, Eq)

--- a/direct-hs/src/Web/Direct/Client/Channel/Types.hs
+++ b/direct-hs/src/Web/Direct/Client/Channel/Types.hs
@@ -84,6 +84,7 @@ send chan msg = createMessage (channelRPCClient chan) msg $ channelTalkId chan
 
 type ChannelKey = (TalkId, Maybe UserId)
 
+-- | User(s) with whome you want to talk.
 data Partner =
       Only User
     | Anyone

--- a/direct-hs/src/Web/Direct/DirectRPC.hs
+++ b/direct-hs/src/Web/Direct/DirectRPC.hs
@@ -106,15 +106,6 @@ getTalkStatuses :: RPC.Client -> IO ()
 getTalkStatuses rpcclient =
     void $ callRpcThrow rpcclient "get_talk_statuses" []
 
-createPairTalk :: RPC.Client -> Domain -> User -> IO TalkRoom
-createPairTalk rpcclient dom peer = do
-    let methodName = "create_pair_talk"
-        did        = domainId dom
-        uid        = userId peer
-        dat        = [M.ObjectWord did, M.ObjectWord uid]
-    rsp <- callRpcThrow rpcclient methodName dat
-    convertOrThrow methodName decodeTalkRoom rsp
-
 deleteTalker :: RPC.Client -> TalkRoom -> User -> IO (Either Exception ())
 deleteTalker rpcclient talk user = do
     let methodName = "delete_talker"

--- a/direct-hs/src/Web/Direct/Internal.hs
+++ b/direct-hs/src/Web/Direct/Internal.hs
@@ -1,0 +1,1 @@
+module Web.Direct.Internal where

--- a/direct-hs/src/Web/Direct/Internal.hs
+++ b/direct-hs/src/Web/Direct/Internal.hs
@@ -1,1 +1,25 @@
-module Web.Direct.Internal where
+module Web.Direct.Internal
+  ( -- * 'Web.Direct.Types'
+    DomainId
+  , TalkId
+  , UserId
+  , MessageId
+  , FileId
+  , FileSize
+  , Domain (..)
+  , TalkType (..)
+  , TalkRoom (..)
+  , User (..)
+  , UploadAuth (..)
+
+    -- * 'Web.Direct.Exception'
+  , callRpcThrow
+  , convertOrThrow
+
+    -- * 'Web.Direct.DirectRPC'
+  , decodeTalkRoom
+  ) where
+
+import Web.Direct.Types
+import Web.Direct.Exception
+import Web.Direct.DirectRPC.Map


### PR DESCRIPTION
This PR make a private RPC method removed.

I remove `create_pair_talk` RPC method from this public repository because it is a private one.

Original `allocateChannel` creates a pair talk in it, but it get not to be able to create a pair talk.
And so new `allocateChannel` must be passed a talk to.

# Breaking change

```diff
- withChannel :: Client -> ChannelType -> (Channel -> IO ()) -> IO Bool
+ withChannel :: Client -> TalkRoom -> Partner -> (Channel -> IO ()) -> IO Bool
```

`withChannel` never create talk rooms. Users must create a talk room before call `withChannel` and pass it.

talk room | partner | previously named
----|----|----
2 participants | one who participates | pair channel
2 participants | anyone | pair channel
many participants | one who participates | pin-point channel
many participants | anyone | group channel
