### PR TITLE
Update acquaintances when addTalkers/deleteTalk/deleteTalker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
         - 'dependencies-{{ checksum "stack.yaml" }}'
         - 'dependencies-'
     - run: stack --compiler=ghc-8.6.5 --no-terminal test --pedantic --no-run-tests
+    - run: stack --compiler=ghc-8.6.5 --no-terminal test --pedantic direct-hs
 
     - save_cache:
         key: 'dependencies-{{ checksum "stack.yaml" }}'

--- a/direct-hs/direct-hs.cabal
+++ b/direct-hs/direct-hs.cabal
@@ -70,6 +70,23 @@ executable direct4b
     , network-messagepack-rpc
   default-language: Haskell2010
 
+test-suite direct-hs-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  other-modules:       Web.Direct.InternalSpec
+  build-depends:
+      base
+    , direct-hs
+    , hspec
+    , text
+    , mtl
+    , network-messagepack-rpc
+  build-tool-depends:
+      hspec-discover:hspec-discover
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+
 source-repository head
   type:     git
   location: https://github.com/iij-ii/direct-hs

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -18,6 +18,7 @@ module Web.Direct
     , getTalkRooms
     , getMe
     , getUsers
+    , getAcquaintances
     , getCurrentDomain
     , getTalkUsers
   -- * Message

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -200,9 +200,7 @@ subscribeNotification client = do
     getFriends rpcclient
 
     let did = domainId $ getCurrentDomain client
-    allAcqs <- getAcquaintances rpcclient
-    let acqs = fromMaybe [] $ lookup did allAcqs
-    setAcquaintances client acqs
+    _ <- initialiseAcquaintances client
     allTalks <- getTalks rpcclient
     let talks = fromMaybe [] $ lookup did allTalks
     setTalkRooms client talks

--- a/direct-hs/src/Web/Direct/Api.hs
+++ b/direct-hs/src/Web/Direct/Api.hs
@@ -233,14 +233,10 @@ handleNotifyCreateMessage config client msg msgid tid uid = do
                         client
                         (msg, msgid, room, user)
 
--- TODO: Check if this kind notification is sent to the user who makes the trigger of the notification:
- --      i.e. called addTalkers
 handleAddAcquaintance :: Client -> DomainId -> User -> IO ()
 handleAddAcquaintance client _did newUser =
     modifyAcquaintances client $ \users -> (newUser : users, ())
 
--- TODO: Check if this kind notification is sent to the user who makes the trigger of the notification:
---       i.e. called removeUserFromTalkRoom, leaveTalkRoom
 handleNotifyDeleteAcquaintance :: Client -> DomainId -> UserId -> IO ()
 handleNotifyDeleteAcquaintance client _did uid = modifyAcquaintances
     client

--- a/direct-hs/src/Web/Direct/Internal.hs
+++ b/direct-hs/src/Web/Direct/Internal.hs
@@ -6,6 +6,7 @@ module Web.Direct.Internal
     -- ** Exposed for testing
     , onAddTalkers
     , onDeleteTalker
+    , onDeleteTalk
     , newClient
     , setTalkRooms
     , hasAcquaintancesCached

--- a/direct-hs/src/Web/Direct/Internal.hs
+++ b/direct-hs/src/Web/Direct/Internal.hs
@@ -3,7 +3,13 @@ module Web.Direct.Internal
     -- * 'Web.Direct.Client'
       clientRpcClient
     , findTalkRoom
+    -- ** Exposed for testing
     , onAddTalkers
+    , onDeleteTalker
+    , newClient
+    , setTalkRooms
+    , hasAcquaintancesCached
+    , setAcquaintances
 
     -- * 'Web.Direct.Exception'
     , callRpc
@@ -12,9 +18,13 @@ module Web.Direct.Internal
 
     -- * 'Web.Direct.DirectRPC'
     , decodeTalkRoom
+
+    -- * 'Web.Direct.Types' (Only for testing)
+    , module Web.Direct.Types
     )
 where
 
 import           Web.Direct.Client
 import           Web.Direct.DirectRPC.Map
 import           Web.Direct.Exception
+import           Web.Direct.Types

--- a/direct-hs/test/Spec.hs
+++ b/direct-hs/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/direct-hs/test/Web/Direct/InternalSpec.hs
+++ b/direct-hs/test/Web/Direct/InternalSpec.hs
@@ -10,8 +10,7 @@ import           Control.Monad                           (replicateM)
 import           Control.Monad.State.Strict              (State, evalState, get,
                                                           put)
 import           Data.Function                           (on)
-import           Data.IORef                              (IORef, newIORef,
-                                                          readIORef, writeIORef)
+import           Data.IORef                              (newIORef)
 import           Data.List                               (deleteBy, partition)
 import qualified Data.Text                               as T
 import           Data.Word                               (Word64)
@@ -137,8 +136,6 @@ spec = do
                     client <- newTestClient me acquaintances existingRooms
 
                     talkRoomsBeforeUpdated <- getTalkRooms client
-
-                    hasReinitialised <- newHasCalled
 
                     onAddTalkers client testDomainId newRoom
 
@@ -336,18 +333,6 @@ genTestUsers =
         <$> (mkTestUser "me" <$> getNewId)
         <*> (mkTestUser "target user" <$> getNewId)
         <*> replicateM 2 (mkTestUser "acquaintance" <$> getNewId)
-
-
-newtype HasCalled = HasCalled (IORef Bool)
-
-newHasCalled :: IO HasCalled
-newHasCalled = HasCalled <$> newIORef False
-
-markAsCalled :: HasCalled -> IO ()
-markAsCalled (HasCalled ref) = writeIORef ref True
-
-askIfHasCalled :: HasCalled -> IO Bool
-askIfHasCalled (HasCalled ref) = readIORef ref
 
 
 tshow :: Show a => a -> T.Text

--- a/direct-hs/test/Web/Direct/InternalSpec.hs
+++ b/direct-hs/test/Web/Direct/InternalSpec.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Web.Direct.InternalSpec
+    ( spec
+    ) where
+
+import           Control.Arrow                           (first)
+import           Control.Monad                           (replicateM)
+import           Control.Monad.State.Strict              (State, evalState, get,
+                                                          put)
+import           Data.IORef                              (IORef, newIORef,
+                                                          readIORef, writeIORef)
+import           Data.List                               (partition)
+import qualified Data.Text                               as T
+import           Data.Word                               (Word64)
+import qualified Network.MessagePack.RPC.Client.Internal as RPC
+import           Test.Hspec
+
+import           Web.Direct
+import           Web.Direct.Internal
+
+spec :: Spec
+spec = do
+    describe "onAddTalkers" $ do
+        context "when client has the talk room with the same ID with the updated talk room's" $ do
+            context "when SOME of the users in the updated talk room are new to the client" $
+                it "the talk room gets new users and invalidate the cache of acquaintances." $ do
+                    let (existingRooms, newRoom, me, newUser, acquaintances) = evalIdGen $ do
+                            (me', newUser', acquaintances') <- genTestUsers
+                            roomIdToUpdate <- getNewId
+                            let newRoom' = mkTestRoom (me' : newUser' : acquaintances) roomIdToUpdate
+                                roomToUpdate = mkTestRoom (me' : acquaintances) roomIdToUpdate
+
+                            otherRoom <- mkTestRoom [me', head acquaintances] <$> getNewId
+
+                            return ([otherRoom, roomToUpdate], newRoom', me', newUser', acquaintances')
+
+                    client <- newTestClient me acquaintances existingRooms
+
+                    (talkRoomBeforeUpdated, otherRoomsBeforeUpdated) <- getSameRoomWithOthers client newRoom
+
+                    onAddTalkers client testDomainId newRoom
+
+                    (updatedTalkRoom, otherRoomsAfterUpdated) <- getSameRoomWithOthers client newRoom
+
+                    talkUserIds updatedTalkRoom
+                        `shouldMatchList` (talkUserIds talkRoomBeforeUpdated ++ [userId newUser])
+
+                    otherRoomsAfterUpdated `shouldBe` otherRoomsBeforeUpdated
+
+                    hasAcquaintancesCached client `shouldReturn` False
+
+            context "when NONE of the users in the updated talk room are new to the client" $
+                it "the talk room gets new users but doesn't invalidate the cache of acquaintances." $ do
+                    let (existingRooms, newRoom, me, newUser, acquaintances) = evalIdGen $ do
+                            (me', newUser', acquaintances') <- genTestUsers
+                            roomIdToUpdate <- getNewId
+                            let newRoom' = mkTestRoom (me' : newUser' : acquaintances) roomIdToUpdate
+                                roomToUpdate = mkTestRoom (me' : acquaintances) roomIdToUpdate
+
+                            otherRoom <- mkTestRoom [me', newUser', head acquaintances] <$> getNewId
+
+                            return ([otherRoom, roomToUpdate], newRoom', me', newUser', newUser' : acquaintances')
+
+                    client <- newTestClient me acquaintances existingRooms
+
+                    (talkRoomBeforeUpdated, otherRoomsBeforeUpdated) <- getSameRoomWithOthers client newRoom
+
+                    onAddTalkers client testDomainId newRoom
+
+                    (updatedTalkRoom, otherRoomsAfterUpdated) <- getSameRoomWithOthers client newRoom
+
+                    talkUserIds updatedTalkRoom
+                        `shouldMatchList` (talkUserIds talkRoomBeforeUpdated ++ [userId newUser])
+
+                    otherRoomsAfterUpdated `shouldBe` otherRoomsBeforeUpdated
+
+                    hasAcquaintancesCached client `shouldReturn` True
+
+        context "when client has NO talk room with the same ID with the updated talk room's" $ do
+            context "when SOME of the users in the updated talk room are new to the client" $
+                it "the client gets the new room and invalidate the cache of acquaintances." $ do
+                    let (existingRooms, newRoom, me, acquaintances) = evalIdGen $ do
+                            (me', newUser', acquaintances') <- genTestUsers
+                            newRoom' <- mkTestRoom (me' : newUser' : acquaintances) <$> getNewId
+                            otherRoom1 <- mkTestRoom [me', head acquaintances] <$> getNewId
+                            otherRoom2 <- mkTestRoom [me', last acquaintances] <$> getNewId
+
+                            return ([otherRoom1, otherRoom2], newRoom', me', acquaintances')
+
+                    client <- newTestClient me acquaintances existingRooms
+
+                    talkRoomsBeforeUpdated <- getTalkRooms client
+
+                    onAddTalkers client testDomainId newRoom
+
+                    talkRoomsAfterUpdated <- getTalkRooms client
+
+                    talkRoomsAfterUpdated `shouldMatchList` newRoom : talkRoomsBeforeUpdated
+
+                    hasAcquaintancesCached client `shouldReturn` False
+
+            context "when NONE of the users in the updated talk room are new to the client" $
+                it "the client gets the new room but doesn't invalidate the cache of acquaintances." $ do
+                    let (existingRooms, newRoom, me, acquaintances) = evalIdGen $ do
+                            (me', newUser', acquaintances') <- genTestUsers
+                            newRoom' <- mkTestRoom (me' : newUser' : acquaintances) <$> getNewId
+                            otherRoom1 <- mkTestRoom [me', newUser', head acquaintances] <$> getNewId
+                            otherRoom2 <- mkTestRoom [me', last acquaintances] <$> getNewId
+
+                            return ([otherRoom1, otherRoom2], newRoom', me', newUser' : acquaintances')
+
+                    client <- newTestClient me acquaintances existingRooms
+
+                    talkRoomsBeforeUpdated <- getTalkRooms client
+
+                    hasReinitialised <- newHasCalled
+
+                    onAddTalkers client testDomainId newRoom
+
+                    talkRoomsAfterUpdated <- getTalkRooms client
+
+                    talkRoomsAfterUpdated `shouldMatchList` newRoom : talkRoomsBeforeUpdated
+
+                    hasAcquaintancesCached client `shouldReturn` True
+
+
+newTestClient :: User -> [User] -> [TalkRoom] -> IO Client
+newTestClient user acqs rooms = do
+    ss <- RPC.initSessionState
+    none <- newIORef Nothing
+    let dontCall = const (error "Don't call backend in this test")
+        testRpcClient = RPC.Client
+            ss
+            ( RPC.Backend
+                dontCall
+                (fail "Don't call backend in this test")
+                (return ())
+            )
+            dontCall
+            dontCall
+            none
+
+    client <- newClient testLoginInfo testRpcClient testDomain user
+    setTalkRooms client rooms
+    setAcquaintances client acqs
+    return client
+  where
+    testLoginInfo = LoginInfo "accessToken" "idfv"
+    testDomain = Domain testDomainId "Test Domain"
+
+mkTestUser :: T.Text -> UserId ->  User
+mkTestUser role uid = User
+    uid
+    (role <> "#" <> tshow uid <> " (Display)")
+    (role <> "#" <> tshow uid <> " (Canonical Display)")
+    (role <> "#" <> tshow uid <> " (Phonetic Display)")
+    (role <> "#" <> tshow uid <> " (Canonical Phonetic Display)")
+
+mkTestRoom :: [User] -> TalkId -> TalkRoom
+mkTestRoom users tid = TalkRoom tid (GroupTalk ("Talk Room " <> tshow tid)) $ map userId users
+
+getSameRoomWithOthers :: HasCallStack => Client -> TalkRoom -> IO (TalkRoom, [TalkRoom])
+getSameRoomWithOthers client room = first head . partition ((== talkId room) . talkId) <$> getTalkRooms client
+
+
+testDomainId :: DomainId
+testDomainId = 9999
+
+type IdGen = State SomeId
+
+type SomeId = Word64
+
+evalIdGen :: IdGen a -> a
+evalIdGen = (`evalState` 1)
+
+getNewId :: IdGen SomeId
+getNewId = do
+    x <- get
+    put $ x + 1
+    return x
+
+
+newtype HasCalled = HasCalled (IORef Bool)
+
+newHasCalled :: IO HasCalled
+newHasCalled = HasCalled <$> newIORef False
+
+markAsCalled :: HasCalled -> IO ()
+markAsCalled (HasCalled ref) = writeIORef ref True
+
+askIfHasCalled :: HasCalled -> IO Bool
+askIfHasCalled (HasCalled ref) = readIORef ref
+
+
+tshow :: Show a => a -> T.Text
+tshow = T.pack . show

--- a/direct-hs/test/Web/Direct/InternalSpec.hs
+++ b/direct-hs/test/Web/Direct/InternalSpec.hs
@@ -33,9 +33,10 @@ spec =
                             let newRoom' = mkTestRoom (me' : newUser' : acquaintances') roomIdToUpdate
                                 roomToUpdate = mkTestRoom (me' : acquaintances') roomIdToUpdate
 
-                            otherRoom <- mkTestRoom [me', head acquaintances'] <$> getNewId
+                            otherRoom1 <- mkTestRoom [me', head acquaintances'] <$> getNewId
+                            otherRoom2 <- mkTestRoom [me', last acquaintances'] <$> getNewId
 
-                            return ([otherRoom, roomToUpdate], newRoom', me', newUser', acquaintances')
+                            return ([otherRoom1, roomToUpdate, otherRoom2], newRoom', me', newUser', acquaintances')
 
                     client <- newTestClient me acquaintances existingRooms
 
@@ -58,9 +59,10 @@ spec =
                             let newRoom' = mkTestRoom (me' : newUser' : acquaintances') roomIdToUpdate
                                 roomToUpdate = mkTestRoom (me' : acquaintances') roomIdToUpdate
 
-                            otherRoom <- mkTestRoom [me', newUser', head acquaintances'] <$> getNewId
+                            otherRoom1 <- mkTestRoom [me', head acquaintances'] <$> getNewId
+                            otherRoom2 <- mkTestRoom [me', last acquaintances'] <$> getNewId
 
-                            return ([otherRoom, roomToUpdate], newRoom', me', newUser', newUser' : acquaintances')
+                            return ([otherRoom1, roomToUpdate, otherRoom2], newRoom', me', newUser', newUser' : acquaintances')
 
                     client <- newTestClient me acquaintances existingRooms
 

--- a/direct-hs/test/Web/Direct/InternalSpec.hs
+++ b/direct-hs/test/Web/Direct/InternalSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Web.Direct.InternalSpec

--- a/direct-hs/test/Web/Direct/InternalSpec.hs
+++ b/direct-hs/test/Web/Direct/InternalSpec.hs
@@ -20,9 +20,10 @@ import           Test.Hspec
 import           Web.Direct
 import           Web.Direct.Internal
 
+
 spec :: Spec
-spec = do
-    describe "onAddTalkers" $ do
+spec =
+    describe "onAddTalkersTestable" $ do
         context "when client has the talk room with the same ID with the updated talk room's" $ do
             context "when SOME of the users in the updated talk room are new to the client" $
                 it "the talk room gets new users and invalidate the cache of acquaintances." $ do
@@ -180,6 +181,13 @@ getNewId = do
     x <- get
     put $ x + 1
     return x
+
+genTestUsers :: IdGen (User, User, [User])
+genTestUsers =
+    (,,)
+        <$> (mkTestUser "me" <$> getNewId)
+        <*> (mkTestUser "target user" <$> getNewId)
+        <*> replicateM 2 (mkTestUser "acquaintance" <$> getNewId)
 
 
 newtype HasCalled = HasCalled (IORef Bool)

--- a/direct-hs/test/Web/Direct/InternalSpec.hs
+++ b/direct-hs/test/Web/Direct/InternalSpec.hs
@@ -44,10 +44,8 @@ spec =
                     onAddTalkers client testDomainId newRoom
 
                     (updatedTalkRoom, otherRoomsAfterUpdated) <- getSameRoomWithOthers client newRoom
-
                     talkUserIds updatedTalkRoom
                         `shouldMatchList` (talkUserIds talkRoomBeforeUpdated ++ [userId newUser])
-
                     otherRoomsAfterUpdated `shouldBe` otherRoomsBeforeUpdated
 
                     hasAcquaintancesCached client `shouldReturn` False
@@ -71,10 +69,8 @@ spec =
                     onAddTalkers client testDomainId newRoom
 
                     (updatedTalkRoom, otherRoomsAfterUpdated) <- getSameRoomWithOthers client newRoom
-
                     talkUserIds updatedTalkRoom
                         `shouldMatchList` (talkUserIds talkRoomBeforeUpdated ++ [userId newUser])
-
                     otherRoomsAfterUpdated `shouldBe` otherRoomsBeforeUpdated
 
                     hasAcquaintancesCached client `shouldReturn` True
@@ -97,7 +93,6 @@ spec =
                     onAddTalkers client testDomainId newRoom
 
                     talkRoomsAfterUpdated <- getTalkRooms client
-
                     talkRoomsAfterUpdated `shouldMatchList` newRoom : talkRoomsBeforeUpdated
 
                     hasAcquaintancesCached client `shouldReturn` False

--- a/direct-hs/test/Web/Direct/InternalSpec.hs
+++ b/direct-hs/test/Web/Direct/InternalSpec.hs
@@ -30,10 +30,10 @@ spec =
                     let (existingRooms, newRoom, me, newUser, acquaintances) = evalIdGen $ do
                             (me', newUser', acquaintances') <- genTestUsers
                             roomIdToUpdate <- getNewId
-                            let newRoom' = mkTestRoom (me' : newUser' : acquaintances) roomIdToUpdate
-                                roomToUpdate = mkTestRoom (me' : acquaintances) roomIdToUpdate
+                            let newRoom' = mkTestRoom (me' : newUser' : acquaintances') roomIdToUpdate
+                                roomToUpdate = mkTestRoom (me' : acquaintances') roomIdToUpdate
 
-                            otherRoom <- mkTestRoom [me', head acquaintances] <$> getNewId
+                            otherRoom <- mkTestRoom [me', head acquaintances'] <$> getNewId
 
                             return ([otherRoom, roomToUpdate], newRoom', me', newUser', acquaintances')
 
@@ -55,10 +55,10 @@ spec =
                     let (existingRooms, newRoom, me, newUser, acquaintances) = evalIdGen $ do
                             (me', newUser', acquaintances') <- genTestUsers
                             roomIdToUpdate <- getNewId
-                            let newRoom' = mkTestRoom (me' : newUser' : acquaintances) roomIdToUpdate
-                                roomToUpdate = mkTestRoom (me' : acquaintances) roomIdToUpdate
+                            let newRoom' = mkTestRoom (me' : newUser' : acquaintances') roomIdToUpdate
+                                roomToUpdate = mkTestRoom (me' : acquaintances') roomIdToUpdate
 
-                            otherRoom <- mkTestRoom [me', newUser', head acquaintances] <$> getNewId
+                            otherRoom <- mkTestRoom [me', newUser', head acquaintances'] <$> getNewId
 
                             return ([otherRoom, roomToUpdate], newRoom', me', newUser', newUser' : acquaintances')
 
@@ -80,9 +80,9 @@ spec =
                 it "the client gets the new room and invalidate the cache of acquaintances." $ do
                     let (existingRooms, newRoom, me, acquaintances) = evalIdGen $ do
                             (me', newUser', acquaintances') <- genTestUsers
-                            newRoom' <- mkTestRoom (me' : newUser' : acquaintances) <$> getNewId
-                            otherRoom1 <- mkTestRoom [me', head acquaintances] <$> getNewId
-                            otherRoom2 <- mkTestRoom [me', last acquaintances] <$> getNewId
+                            newRoom' <- mkTestRoom (me' : newUser' : acquaintances') <$> getNewId
+                            otherRoom1 <- mkTestRoom [me', head acquaintances'] <$> getNewId
+                            otherRoom2 <- mkTestRoom [me', last acquaintances'] <$> getNewId
 
                             return ([otherRoom1, otherRoom2], newRoom', me', acquaintances')
 
@@ -101,9 +101,9 @@ spec =
                 it "the client gets the new room but doesn't invalidate the cache of acquaintances." $ do
                     let (existingRooms, newRoom, me, acquaintances) = evalIdGen $ do
                             (me', newUser', acquaintances') <- genTestUsers
-                            newRoom' <- mkTestRoom (me' : newUser' : acquaintances) <$> getNewId
-                            otherRoom1 <- mkTestRoom [me', newUser', head acquaintances] <$> getNewId
-                            otherRoom2 <- mkTestRoom [me', last acquaintances] <$> getNewId
+                            newRoom' <- mkTestRoom (me' : newUser' : acquaintances') <$> getNewId
+                            otherRoom1 <- mkTestRoom [me', newUser', head acquaintances'] <$> getNewId
+                            otherRoom2 <- mkTestRoom [me', last acquaintances'] <$> getNewId
 
                             return ([otherRoom1, otherRoom2], newRoom', me', newUser' : acquaintances')
 

--- a/direct4bi/direct4bi.cabal
+++ b/direct4bi/direct4bi.cabal
@@ -24,7 +24,6 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , Win32
     , bytestring
     , direct-hs
     , errors
@@ -33,6 +32,9 @@ library
     , optparse-applicative
     , pretty-simple
     , text
+  if os(windows)
+    build-depends:
+        Win32
   default-language: Haskell2010
 
 executable direct4bi

--- a/direct4bi/src/Web/Direct/CLI/Interactive.hs
+++ b/direct4bi/src/Web/Direct/CLI/Interactive.hs
@@ -28,14 +28,14 @@ import qualified Options.Applicative      as Opt
 import qualified System.Console.Haskeline as Hl
 import           System.Exit              (die)
 import qualified System.FilePath          as FP
-import           System.IO                (hFlush, hPutStrLn, hSetEncoding,
-                                           stderr, stdout)
+import           System.IO                (hFlush, hPutStrLn, stderr, stdout)
 import           Text.Pretty.Simple       (pPrint, pShow)
 import           Text.Read                (readMaybe)
 
 #ifdef mingw32_HOST_OS
 import           GHC.IO.Encoding.CodePage (mkLocaleEncoding)
 import           GHC.IO.Encoding.Failure  (CodingFailureMode (TransliterateCodingFailure))
+import           System.IO                (hSetEncoding)
 #endif
 
 import qualified Web.Direct               as D

--- a/network-messagepack-rpc/network-messagepack-rpc.cabal
+++ b/network-messagepack-rpc/network-messagepack-rpc.cabal
@@ -16,6 +16,7 @@ library
   ghc-options: -Wall
   exposed-modules: Data.MessagePack.RPC
                  , Network.MessagePack.RPC.Client
+                 , Network.MessagePack.RPC.Client.Internal
   build-depends:
       base >= 4.7 && < 5
     , bytestring

--- a/network-messagepack-rpc/src/Network/MessagePack/RPC/Client/Internal.hs
+++ b/network-messagepack-rpc/src/Network/MessagePack/RPC/Client/Internal.hs
@@ -1,0 +1,49 @@
+module Network.MessagePack.RPC.Client.Internal where
+
+import           Control.Concurrent      (ThreadId)
+import           Control.Concurrent.MVar (MVar)
+import qualified Data.ByteString         as B
+import           Data.HashMap.Strict     (HashMap)
+import qualified Data.HashMap.Strict     as HM
+import           Data.IORef              (IORef)
+import qualified Data.IORef              as IORef
+import qualified Data.MessagePack        as MsgPack
+
+import           Data.MessagePack.RPC
+
+-- | A client data type for MessagePack RPC.
+data Client = Client {
+    clientSessionState :: !SessionState
+  , clientBackend      :: !Backend
+  , clientLog          :: Logger
+  , clientFormat       :: Formatter
+  , clientHandlerTid   :: IORef (Maybe ThreadId)
+  }
+
+data SessionState = SessionState {
+    lastMessageId :: IORef MessageId
+  , dispatchTable :: IORef (HashMap MessageId (MVar Result))
+  }
+
+-- | Backend IO functions.
+--   Any receiving / sending actions are performed by calling these functions.
+data Backend = Backend {
+    backendSend  :: B.ByteString -> IO () -- ^ Sending
+  , backendRecv  :: IO B.ByteString -- ^ Receiving
+  , backendClose :: IO () -- ^ Closing
+  }
+
+-- | Logger type. Should print out the message passed as a first argument somewhere.
+type Logger = String -> IO ()
+
+-- | Convert 'Message' into a @String@ to print out by 'Logger'
+type Formatter = Message -> String
+
+-- | Result type of a RPC call.
+--   Described as "error" and "result" of "Response Message"
+--   in [the spec of MessagePack RPC](https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md#response-message).
+type Result = Either MsgPack.Object MsgPack.Object
+
+initSessionState :: IO SessionState
+initSessionState =
+    SessionState <$> IORef.newIORef 0 <*> IORef.newIORef HM.empty


### PR DESCRIPTION
- Update acquaintances when receiving these notifications from direct4b.com:
    - `notify_add_talkers`
    - `notify_delete_talk`
    - `notify_delete_talker`
- Tests without accessing to direct4b.com, for the functions called when receiving the notifications above.
    - Expose some functions in direct-hs and network-messagepack-rpc for testing.
- New way to store `acquaintances` of `Client`:
    - When receiving `notify_add_talkers`, the client can get only the user IDs of the new talkers: the client **can't update `acquaintances` due to lack of the details (such as screen names) of the new talkers**.
    - In addition, direct4b.com doesn't seem to provide some API to get details of a user by the user ID anyway!
    - To get correct and up-to-date information of acquaintances, I decided not to update acquaintances immediately after receiving `notify_add_talkers`: Instead, **invalidate the cache of `acquaintances`** when the client should get the details of new talkers after receiving `notify_add_talkers`.
    - After invalidating the cache of `acquaintances`, `getAcquaintances` and `modifyAcquaintances` automatically call the MessagePack RPC function `get_acquaintances` to get correct and up-to-date information of acquaintances again then cache it.