### PR TITLE
Make SelectA have the number of the answer instead of the text of it

### DIFF
--- a/direct-hs-examples/src/ping.hs
+++ b/direct-hs-examples/src/ping.hs
@@ -60,9 +60,9 @@ handleCreateMessage client (D.Txt "talks", _, room, _) = do
     void $ D.sendMessage client
                          (D.Txt (ans `T.append` "があります。"))
                          (D.talkId room)
-handleCreateMessage client (D.SelectA "好きなクワガタは？" _ ans, _, room, _) =
+handleCreateMessage client (D.SelectA "好きなクワガタは？" opt ans, _, room, _) =
     void $ D.sendMessage client
-                         (D.Txt (ans `T.append` "が好きなんですね。"))
+                         (D.Txt (D.getSelectedAnswer opt ans `T.append` "が好きなんですね。"))
                          (D.talkId room)
 handleCreateMessage client (D.YesNoA "お元気ですか？" True, _, room, _) =
     void $ D.sendMessage client (D.Txt "よかったです。") (D.talkId room)

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -27,6 +27,7 @@ module Web.Direct
     , TalkId
     , UserId
     , MessageId
+    , SelectAnswerNumber
   -- ** Abstract types
   -- *** Domain
     , Domain
@@ -79,6 +80,7 @@ module Web.Direct
     , defaultNotificationHandlers
   -- * Utility
     , throttleDown
+    , getSelectedAnswer
     )
 where
 
@@ -87,5 +89,6 @@ import           Web.Direct.Client
 import           Web.Direct.DirectRPC (throttleDown)
 import           Web.Direct.Exception
 import           Web.Direct.LoginInfo
+import           Web.Direct.Message
 import           Web.Direct.Types
 import           Web.Direct.Upload

--- a/direct-hs/src/Web/Direct/Types.hs
+++ b/direct-hs/src/Web/Direct/Types.hs
@@ -6,21 +6,21 @@ import           Data.Word (Word64)
 ----------------------------------------------------------------
 
 -- | Domain ID.
-type DomainId  = Word64
+type DomainId           = Word64
 -- | Talk room ID.
-type TalkId    = Word64
+type TalkId             = Word64
 -- | User ID.
-type UserId    = Word64
+type UserId             = Word64
 -- | Mesage ID.
-type MessageId = Word64
+type MessageId          = Word64
 -- | Timestamp
-type Timestamp = Word64
+type Timestamp          = Word64
 -- | Answer number of a 'SelectA'
 type SelectAnswerNumber = Word64
 -- | (Uploaded) File ID.
-type FileId    = Word64
+type FileId             = Word64
 -- | (Uploaded) File size in bytes.
-type FileSize  = Word64
+type FileSize           = Word64
 
 ----------------------------------------------------------------
 

--- a/direct-hs/src/Web/Direct/Types.hs
+++ b/direct-hs/src/Web/Direct/Types.hs
@@ -15,6 +15,8 @@ type UserId    = Word64
 type MessageId = Word64
 -- | Timestamp
 type Timestamp = Word64
+-- | Answer number of a 'SelectA'
+type SelectAnswerNumber = Word64
 -- | (Uploaded) File ID.
 type FileId    = Word64
 -- | (Uploaded) File size in bytes.
@@ -59,7 +61,7 @@ data Message =
     | YesNoQ    !T.Text
     | YesNoA    !T.Text Bool
     | SelectQ   !T.Text ![T.Text]
-    | SelectA   !T.Text ![T.Text] T.Text
+    | SelectA   !T.Text ![T.Text] SelectAnswerNumber
     | TaskQ     !T.Text Bool -- False: anyone, True: everyone
     | TaskA     !T.Text Bool Bool -- done
     | Files     ![File] !(Maybe T.Text)


### PR DESCRIPTION
- IMO constructors of `Message` should represent the actual payload as correctly as possible.
- It's hard and verbose to type a `SelectA` value constructor in `direct4bi`:
    - Current `post` command of `direct4bi` receives a `Message` via `Read` instance.
      So before this commit, we have to type question, all options, and the answer as a text.