### PR TITLE
Add closingType and inReplyTo to various Q/A Messages

### DIFF
--- a/direct-hs-examples/src/nippo.hs
+++ b/direct-hs-examples/src/nippo.hs
@@ -59,13 +59,13 @@ nippo peer chan = do
     askEvaluation = do
         void $ D.send
             chan
-            (D.SelectQ "達成度はどれくらいですか？" ["100", "75", "50", "25", "0"])
+            (D.SelectQ $ D.SelectQuestion "達成度はどれくらいですか？" ["100", "75", "50", "25", "0"] D.OnlyOne)
         recvLoop
       where
         recvLoop = do
             (msg, _msgid, _room, _user) <- D.recv chan
             case msg of
-                D.SelectA _ _ ans -> return ans
+                D.SelectA sa -> return $ D.getSelectedAnswer sa
                 _                 -> do
                     void $ D.send chan (D.Txt "数値を選んでください。")
                     recvLoop

--- a/direct-hs-examples/src/ping.hs
+++ b/direct-hs-examples/src/ping.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings     #-}
 
 module Main
     ( main
@@ -31,13 +32,13 @@ handleCreateMessage client (D.Txt "stamp", _, room, _) = void $ D.sendMessage
     (D.Stamp 3 1152921507291204297 (Just "スタンプ！"))
     (D.talkId room)
 handleCreateMessage client (D.Txt "yesno", _, room, _) =
-    void $ D.sendMessage client (D.YesNoQ "お元気ですか？") (D.talkId room)
+    void $ D.sendMessage client (D.YesNoQ $ D.YesNoQuestion "お元気ですか？" D.Anyone) (D.talkId room)
 handleCreateMessage client (D.Txt "select", _, room, _) = void $ D.sendMessage
     client
-    (D.SelectQ "好きなクワガタは？" ["ヒラタ", "ミヤマ", "オオ"])
+    (D.SelectQ $ D.SelectQuestion "好きなクワガタは？" ["ヒラタ", "ミヤマ", "オオ"] D.Anyone)
     (D.talkId room)
 handleCreateMessage client (D.Txt "task", _, room, _) =
-    void $ D.sendMessage client (D.TaskQ "高速化できる？" False) (D.talkId room)
+    void $ D.sendMessage client (D.TaskQ $ D.TaskQuestion "高速化できる？" D.Anyone) (D.talkId room)
 handleCreateMessage client (D.Txt "whoareyou", _, room, _) = do
     me <- D.getMe client
     void $ D.sendMessage
@@ -60,17 +61,17 @@ handleCreateMessage client (D.Txt "talks", _, room, _) = do
     void $ D.sendMessage client
                          (D.Txt (ans `T.append` "があります。"))
                          (D.talkId room)
-handleCreateMessage client (D.SelectA "好きなクワガタは？" _ ans, _, room, _) =
+handleCreateMessage client (D.SelectA sa@D.SelectAnswer { D.question = "好きなクワガタは？" }, _, room, _) =
     void $ D.sendMessage client
-                         (D.Txt (ans `T.append` "が好きなんですね。"))
+                         (D.Txt (D.getSelectedAnswer sa `T.append` "が好きなんですね。"))
                          (D.talkId room)
-handleCreateMessage client (D.YesNoA "お元気ですか？" True, _, room, _) =
+handleCreateMessage client (D.YesNoA D.YesNoAnswer { D.question = "お元気ですか？", D.response = True }, _, room, _) =
     void $ D.sendMessage client (D.Txt "よかったです。") (D.talkId room)
-handleCreateMessage client (D.YesNoA "お元気ですか？" False, _, room, _) =
+handleCreateMessage client (D.YesNoA D.YesNoAnswer { D.question = "お元気ですか？", D.response = False }, _, room, _) =
     void $ D.sendMessage client (D.Txt "元気出してね。") (D.talkId room)
-handleCreateMessage client (D.TaskA "高速化できる？" _ True, _, room, _) =
+handleCreateMessage client (D.TaskA D.TaskAnswer { D.title = "高速化できる？", D.done = True }, _, room, _) =
     void $ D.sendMessage client (D.Txt "よくできました。") (D.talkId room)
-handleCreateMessage client (D.TaskA "高速化できる？" _ False, _, room, _) =
+handleCreateMessage client (D.TaskA D.TaskAnswer { D.title = "高速化できる？", D.done = False }, _, room, _) =
     void $ D.sendMessage client (D.Txt "できないんだ。") (D.talkId room)
 handleCreateMessage client (D.Location addr _url, _, room, _) =
     void $ D.sendMessage client

--- a/direct-hs/direct-hs.cabal
+++ b/direct-hs/direct-hs.cabal
@@ -82,6 +82,7 @@ test-suite direct-hs-test
     , text
     , mtl
     , network-messagepack-rpc
+    , data-msgpack-types
   build-tool-depends:
       hspec-discover:hspec-discover
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/direct-hs/direct-hs.cabal
+++ b/direct-hs/direct-hs.cabal
@@ -36,6 +36,7 @@ library
     , bytestring
     , containers
     , data-msgpack
+    , data-msgpack-types
     , errors
     , filepath
     , http-client

--- a/direct-hs/src/Web/Direct.hs
+++ b/direct-hs/src/Web/Direct.hs
@@ -47,6 +47,13 @@ module Web.Direct
     , canonicalPhoneticDisplayName
   -- ** Message
     , Message(..)
+    , YesNoQuestion(..)
+    , YesNoAnswer(..)
+    , SelectQuestion(..)
+    , SelectAnswer(..)
+    , TaskQuestion(..)
+    , TaskAnswer(..)
+    , ClosingType(..)
   -- * Sending
     , sendMessage
   -- ** File Upload
@@ -79,6 +86,7 @@ module Web.Direct
     , defaultNotificationHandlers
   -- * Utility
     , throttleDown
+    , getSelectedAnswer
     )
 where
 
@@ -87,5 +95,6 @@ import           Web.Direct.Client
 import           Web.Direct.DirectRPC (throttleDown)
 import           Web.Direct.Exception
 import           Web.Direct.LoginInfo
+import           Web.Direct.Message
 import           Web.Direct.Types
 import           Web.Direct.Upload

--- a/direct-hs/src/Web/Direct/Internal.hs
+++ b/direct-hs/src/Web/Direct/Internal.hs
@@ -13,6 +13,7 @@ module Web.Direct.Internal
     , hasAcquaintancesCached
     , setAcquaintances
     , invalidateCachedAcquaintances
+    , decodeMessage
 
     -- * 'Web.Direct.Exception'
     , callRpc
@@ -29,4 +30,5 @@ where
 import           Web.Direct.Client
 import           Web.Direct.DirectRPC.Map
 import           Web.Direct.Exception
+import           Web.Direct.Message
 import           Web.Direct.Types

--- a/direct-hs/src/Web/Direct/Message.hs
+++ b/direct-hs/src/Web/Direct/Message.hs
@@ -53,42 +53,42 @@ encodeMessage (YesNoQ (YesNoQuestion qst ct)) tid =
     [ M.ObjectWord tid
     , M.ObjectWord 500
     , M.ObjectMap
-        [ (M.ObjectStr "question", M.ObjectStr qst)
+        [ (M.ObjectStr "question"    , M.ObjectStr qst)
         , (M.ObjectStr "closing_type", M.toObject ct)
-        , (M.ObjectStr "listing" , M.ObjectBool False)
+        , (M.ObjectStr "listing"     , M.ObjectBool False)
         ]
     ]
 encodeMessage (YesNoA (YesNoAnswer qst ct ans irl)) tid =
     [ M.ObjectWord tid
     , M.ObjectWord 501
     , M.ObjectMap
-        [ (M.ObjectStr "question", M.ObjectStr qst)
+        [ (M.ObjectStr "question"    , M.ObjectStr qst)
         , (M.ObjectStr "closing_type", M.toObject ct)
-        , (M.ObjectStr "response", M.ObjectBool ans)
-        , (M.ObjectStr "in_reply_to", M.ObjectWord irl)
-        , (M.ObjectStr "listing" , M.ObjectBool False)
+        , (M.ObjectStr "response"    , M.ObjectBool ans)
+        , (M.ObjectStr "in_reply_to" , M.ObjectWord irl)
+        , (M.ObjectStr "listing"     , M.ObjectBool False)
         ]
     ]
 encodeMessage (SelectQ (SelectQuestion qst opt ct)) tid =
     [ M.ObjectWord tid
     , M.ObjectWord 502
     , M.ObjectMap
-        [ (M.ObjectStr "question", M.ObjectStr qst)
-        , (M.ObjectStr "options" , M.toObject opt)
+        [ (M.ObjectStr "question"    , M.ObjectStr qst)
+        , (M.ObjectStr "options"     , M.toObject opt)
         , (M.ObjectStr "closing_type", M.toObject ct)
-        , (M.ObjectStr "listing" , M.ObjectBool False)
+        , (M.ObjectStr "listing"     , M.ObjectBool False)
         ]
     ]
 encodeMessage (SelectA (SelectAnswer qst opt ct ans irl)) tid =
     [ M.ObjectWord tid
     , M.ObjectWord 503
     , M.ObjectMap
-        [ (M.ObjectStr "question", M.ObjectStr qst)
-        , (M.ObjectStr "options" , M.toObject opt)
+        [ (M.ObjectStr "question"    , M.ObjectStr qst)
+        , (M.ObjectStr "options"     , M.toObject opt)
         , (M.ObjectStr "closing_type", M.toObject ct)
-        , (M.ObjectStr "response", M.toObject ans)
-        , (M.ObjectStr "in_reply_to", M.ObjectWord irl)
-        , (M.ObjectStr "listing" , M.ObjectBool False)
+        , (M.ObjectStr "response"    , M.toObject ans)
+        , (M.ObjectStr "in_reply_to" , M.ObjectWord irl)
+        , (M.ObjectStr "listing"     , M.ObjectBool False)
         ]
     ]
 encodeMessage (TaskQ (TaskQuestion ttl ct)) tid =
@@ -106,7 +106,7 @@ encodeMessage (TaskA (TaskAnswer ttl ct don irl)) tid =
         [ (M.ObjectStr "title"       , M.ObjectStr ttl)
         , (M.ObjectStr "closing_type", M.toObject ct)
         , (M.ObjectStr "done"        , M.ObjectBool don)
-        , (M.ObjectStr "in_reply_to", M.ObjectWord irl)
+        , (M.ObjectStr "in_reply_to" , M.ObjectWord irl)
         ]
     ]
 

--- a/direct-hs/src/Web/Direct/Message.hs
+++ b/direct-hs/src/Web/Direct/Message.hs
@@ -165,7 +165,7 @@ decodeMessage rspinfo = do
                 YesNoQ <$> decodeYesNoQuestion m
             M.ObjectWord 501 -> do
                 M.ObjectMap m <- look "content" rspinfo
-                (YesNoQuestion qst ct) <- decodeYesNoQuestion m
+                YesNoQuestion qst ct <- decodeYesNoQuestion m
                 ans           <- look "response" m >>= M.fromObject
                 irl           <- decodeInReplyTo m
                 return . YesNoA $ YesNoAnswer qst ct ans irl

--- a/direct-hs/src/Web/Direct/Types.hs
+++ b/direct-hs/src/Web/Direct/Types.hs
@@ -10,23 +10,23 @@ import           GHC.Generics (Generic)
 ----------------------------------------------------------------
 
 -- | Domain ID.
-type DomainId  = Word64
+type DomainId           = Word64
 -- | Talk room ID.
-type TalkId    = Word64
+type TalkId             = Word64
 -- | User ID.
-type UserId    = Word64
+type UserId             = Word64
 -- | Message ID.
-type MessageId = Word64
+type MessageId          = Word64
 -- | Timestamp
-type Timestamp = Word64
+type Timestamp          = Word64
 -- | Answer number of a 'SelectA'
 --   Actually values of this type are exchanged as unsigned integers,
 --   but I chose 'Int' for compatibility with '!!'.
 type SelectAnswerNumber = Int
 -- | (Uploaded) File ID.
-type FileId    = Word64
+type FileId             = Word64
 -- | (Uploaded) File size in bytes.
-type FileSize  = Word64
+type FileSize           = Word64
 
 ----------------------------------------------------------------
 

--- a/direct-hs/src/Web/Direct/Types.hs
+++ b/direct-hs/src/Web/Direct/Types.hs
@@ -3,9 +3,10 @@
 
 module Web.Direct.Types where
 
-import qualified Data.Text    as T
-import           Data.Word    (Word64)
-import           GHC.Generics (Generic)
+import qualified Data.MessagePack.Types as M
+import qualified Data.Text              as T
+import           Data.Word              (Word64)
+import           GHC.Generics           (Generic)
 
 ----------------------------------------------------------------
 
@@ -99,6 +100,17 @@ data TaskAnswer = TaskAnswer
     deriving (Eq, Show, Read, Generic)
 
 data ClosingType = OnlyOne | Anyone deriving (Eq, Show, Read, Generic)
+
+instance M.MessagePack ClosingType where
+    toObject OnlyOne = M.ObjectWord 0
+    toObject Anyone  = M.ObjectWord 1
+
+    fromObject m = do
+        i <- M.fromObject m
+        case i :: Int of
+            0 -> return OnlyOne
+            1 -> return Anyone
+            _ -> fail $ "Unknown ClosingType: " ++ show i
 
 data File = File
     { fileUrl         :: !T.Text


### PR DESCRIPTION
The most important commit is https://github.com/iij-ii/direct-hs/commit/a3be5a3fe3bd2bac95f169c5da96bbd9173699d5
- Use `DuplicateRecordFields` for easier abstraction of record fields.
- Add `Generic` instances to `Message` and its related types to make them compatible with generic-lens.
- Plus revised version of https://github.com/iij-ii/direct-hs/pull/98/commits/965d775df409804333b4a3d40a3fad458ae7f93e